### PR TITLE
Grammar 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /node_modules
 /out
+/.settings

--- a/lib/models.js
+++ b/lib/models.js
@@ -420,7 +420,7 @@ class BooleanConstraint extends Constraint {
 }
 
 class TypeConstraint extends Constraint {
-  constructor(isA, path, onValue) {
+  constructor(isA, path, onValue = false) {
     super(path);
     this._isA = isA;
     this._onValue = onValue;
@@ -429,9 +429,18 @@ class TypeConstraint extends Constraint {
   get isA() { return this._isA; }
 
   get onValue() { return this._onValue; }
+  set onValue(onValue) {
+    this._onValue = onValue;
+  }
+  // withOnValue is a convenience function for chaining
+  withOnValue(onValue) {
+    this.onValue = onValue;
+    return this;
+  }
 
   clone() {
     const clone = new TypeConstraint(this._isA.clone());
+    clone.onValue = this._onValue;
     this._clonePropertiesTo(clone);
     return clone;
   }

--- a/lib/models.js
+++ b/lib/models.js
@@ -286,6 +286,22 @@ class CodeConstraint extends Constraint {
   }
 }
 
+// IncludesCodeConstraint only makes sense on an array of code or Coding
+class IncludesCodeConstraint extends Constraint {
+  constructor(code, path) {
+    super(path);
+    this._code = code;
+  }
+
+  get code() { return this._code; }
+
+  clone() {
+    const clone = new IncludesCodeConstraint(this._code.clone());
+    this._clonePropertiesTo(clone);
+    return clone;
+  }
+}
+
 class TypeConstraint extends Constraint {
   constructor(isA, path) {
     super(path);
@@ -347,6 +363,10 @@ class ConstraintsFilter {
 
   get code() {
     return new ConstraintsFilter(this._constraints.filter(c => c instanceof CodeConstraint));
+  }
+
+  get includesCode() {
+    return new ConstraintsFilter(this._constraints.filter(c => c instanceof IncludesCodeConstraint));
   }
 
   get type() {
@@ -565,4 +585,4 @@ const PRIMITIVE_NS = 'primitive';
 const PRIMITIVES = ['boolean', 'integer', 'decimal', 'unsignedInt', 'positiveInt', 'string', 'markdown', 'code', 'id',
   'oid', 'uri', 'base64Binary', 'date', 'dateTime', 'instant', 'time'];
 
-module.exports = {Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, TypeConstraint, CardConstraint, PRIMITIVE_NS, PRIMITIVES};
+module.exports = {Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, TypeConstraint, CardConstraint, PRIMITIVE_NS, PRIMITIVES};

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,9 +1,108 @@
+class Specifications {
+  constructor() {
+    this._namespaces = new NamespaceSpecifications();
+    this._dataElements = new DataElementSpecifications();
+    /* For later
+    this._valueSets = new ValueSetSpecifications();
+    this._maps = new MapSpecifications();
+    */
+  }
+
+  get namespaces() { return this._namespaces; }
+  get dataElements() { return this._dataElements; }
+  /* For later
+  get valueSets() { return this._valueSets; }
+  get maps() { return this._maps; }
+  */
+}
+
+class NamespaceSpecifications {
+  constructor() {
+    this._nsMap = new Map();
+  }
+
+  add(namespace) {
+    this._nsMap.set(namespace.namespace, namespace);
+  }
+
+  get all() { return Array.from(this._nsMap.values()); }
+
+  find(namespace) {
+    return this._nsMap.get(namespace);
+  }
+}
+
+class DataElementSpecifications {
+  constructor() {
+    this._nsMap = new Map();
+    this._grammarVersions = new Map();
+  }
+
+  get grammarVersions() { return Array.from(this._grammarVersions.values()); }
+  get namespaces() { return Array.from(this._nsMap.keys()); }
+
+  add(dataElement) {
+    const id = dataElement.identifier;
+    if (!this._nsMap.has(id.namespace)) {
+      this._nsMap.set(id.namespace, new Map());
+    }
+    this._nsMap.get(id.namespace).set(id.name, dataElement);
+    if (typeof dataElement.grammarVersion !== 'undefined') {
+      this._grammarVersions.set(dataElement.grammarVersion.toString(), dataElement.grammarVersion);
+    }
+  }
+
+  get all() {
+    const all = [];
+    for (const ns of this._nsMap.values()) {
+      all.push(...ns.values());
+    }
+    return all;
+  }
+
+  get entries() {
+    return this.all.filter(de => de.isEntry);
+  }
+
+  byNamespace(namespace) {
+    if (this._nsMap.has(namespace)) {
+      return Array.from(this._nsMap.get(namespace).values());
+    }
+    return [];
+  }
+
+  entriesByNamespace(namespace) {
+    if (this._nsMap.has(namespace)) {
+      return this.byNamespace(namespace).filter(de => de.isEntry);
+    }
+    return [];
+  }
+
+  find(namespace, name) {
+    if (this._nsMap.has(namespace)) {
+      return this._nsMap.get(namespace).get(name);
+    }
+  }
+
+  findByIdentifier(identifier) {
+    return this.find(identifier.namespace, identifier.name);
+  }
+}
+
+/* For later
+class ValueSetSpecifications {
+
+}
+
+class MapSpecifications {
+
+}
+*/
+
 class Namespace {
   constructor(namespace, description) {
     this._namespace = namespace; // string
     this._description = description; // string
-    this._definitionIdentifiers = []; // Identifier[] (keeping track in an array allows us to preserve order)
-    this._definitionMap = {}; // obj[string]=DataElement
   }
 
   get namespace() { return this._namespace; }
@@ -19,32 +118,8 @@ class Namespace {
     return this;
   }
 
-  get definitions() { return this._definitionIdentifiers.map(id => this._definitionMap[id]); }
-  addDefinition(definition) {
-    if (typeof this.lookup(definition.identifier.name) === 'undefined') {
-      this._definitionIdentifiers.push(definition.identifier.name);
-    }
-    this._definitionMap[definition.identifier.name] = definition;
-  }
-  // withDefinition is a convenience function for chaining
-  withDefinition(definition) {
-    this.addDefinition(definition);
-    return this;
-  }
-
-  lookup(name) {
-    return this._definitionMap[name];
-  }
-
   clone() {
-    const clone = new Namespace(this._namespace);
-    for (const id of this._definitionIdentifiers) {
-      clone._definitionIdentifiers.push(id.clone());
-    }
-    for (const name of this._definitionMap) {
-      clone._definitionMap[name] = this._definitionMap[name].clone();
-    }
-    return clone;
+    return new Namespace(this._namespace, this._description);
   }
 }
 
@@ -55,7 +130,7 @@ class DataElement {
     this._basedOn = [];      // Identifier[]
     this._concepts = [];     // Concept[]
     this._fields = [];       // Value[] (and its subclasses) -- excluding primitive values
-    // also contains _value and _description
+    // also contains _value, _description, and _grammarVersion
   }
 
   // identifier is the unique Identifier (namespace+name) for the DataElement
@@ -130,6 +205,17 @@ class DataElement {
     return this;
   }
 
+  // the Version of the grammar used to define this element
+  get grammarVersion() { return this._grammarVersion; }
+  set grammarVersion(grammarVersion) {
+    this._grammarVersion = grammarVersion;
+  }
+  // withGrammarVersion is a convenience function for chaining
+  withGrammarVersion(grammarVersion) {
+    this.grammarVersion = grammarVersion;
+    return this;
+  }
+
   clone() {
     const clone = new DataElement(this._identifier.clone(), this._isEntry);
     if (this._description) {
@@ -146,6 +232,9 @@ class DataElement {
     }
     for (const field of this._fields) {
       clone._fields.push(field.clone());
+    }
+    if (this._grammarVersion) {
+      clone._grammarVersion = this._grammarVersion;
     }
     return clone;
   }
@@ -638,4 +727,4 @@ const PRIMITIVE_NS = 'primitive';
 const PRIMITIVES = ['boolean', 'integer', 'decimal', 'unsignedInt', 'positiveInt', 'string', 'markdown', 'code', 'id',
   'oid', 'uri', 'base64Binary', 'date', 'dateTime', 'instant', 'time'];
 
-module.exports = {Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION};
+module.exports = {Specifications, NamespaceSpecifications, DataElementSpecifications, Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION};

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,11 +1,23 @@
 class Namespace {
-  constructor(namespace) {
+  constructor(namespace, description) {
     this._namespace = namespace; // string
+    this._description = description; // string
     this._definitionIdentifiers = []; // Identifier[] (keeping track in an array allows us to preserve order)
     this._definitionMap = {}; // obj[string]=DataElement
   }
 
   get namespace() { return this._namespace; }
+
+  // a description is a string
+  get description() { return this._description; }
+  set description(description) {
+    this._description = description;
+  }
+  // withDescription is a convenience function for chaining
+  withDescription(description) {
+    this.description = description;
+    return this;
+  }
 
   get definitions() { return this._definitionIdentifiers.map(id => this._definitionMap[id]); }
   addDefinition(definition) {
@@ -302,6 +314,22 @@ class IncludesCodeConstraint extends Constraint {
   }
 }
 
+// BooleanConstraint only makes sense on a boolean
+class BooleanConstraint extends Constraint {
+  constructor(value, path) {
+    super(path);
+    this._value = value;
+  }
+
+  get value() { return this._value; }
+
+  clone() {
+    const clone = new BooleanConstraint(this._value);
+    this._clonePropertiesTo(clone);
+    return clone;
+  }
+}
+
 class TypeConstraint extends Constraint {
   constructor(isA, path) {
     super(path);
@@ -367,6 +395,10 @@ class ConstraintsFilter {
 
   get includesCode() {
     return new ConstraintsFilter(this._constraints.filter(c => c instanceof IncludesCodeConstraint));
+  }
+
+  get boolean() {
+    return new ConstraintsFilter(this._constraints.filter(c => c instanceof BooleanConstraint));
   }
 
   get type() {
@@ -581,8 +613,26 @@ class TBD extends Value{
   }
 }
 
+class Version {
+  constructor(major, minor = 0, patch = 0) {
+    this._major = major;
+    this._minor = minor;
+    this._patch = patch;
+  }
+
+  get major() { return this._major; }
+  get minor() { return this._minor; }
+  get patch() { return this._patch; }
+
+  toString() {
+    return `${this.major}.${this.minor}.${this.patch}`;
+  }
+}
+
+const VERSION = new Version(4, 0, 0);
+const GRAMMAR_VERSION = new Version(4, 0, 0);
 const PRIMITIVE_NS = 'primitive';
 const PRIMITIVES = ['boolean', 'integer', 'decimal', 'unsignedInt', 'positiveInt', 'string', 'markdown', 'code', 'id',
   'oid', 'uri', 'base64Binary', 'date', 'dateTime', 'instant', 'time'];
 
-module.exports = {Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, TypeConstraint, CardConstraint, PRIMITIVE_NS, PRIMITIVES};
+module.exports = {Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION};

--- a/lib/models.js
+++ b/lib/models.js
@@ -331,12 +331,15 @@ class BooleanConstraint extends Constraint {
 }
 
 class TypeConstraint extends Constraint {
-  constructor(isA, path) {
+  constructor(isA, path, onValue) {
     super(path);
     this._isA = isA;
+    this._onValue = onValue;
   }
 
   get isA() { return this._isA; }
+
+  get onValue() { return this._onValue; }
 
   clone() {
     const clone = new TypeConstraint(this._isA.clone());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Models used to represent SHR namespaces and data elements for import/export",
   "author": "",
   "license": "Apache-2.0",

--- a/test/specifications-test.js
+++ b/test/specifications-test.js
@@ -1,0 +1,149 @@
+const {expect} = require('chai');
+const mdl = require('../index');
+
+describe('#Specifications', () => {
+  it('should correctly initialize its components', () => {
+    const specs = new mdl.Specifications();
+    expect(specs.namespaces.all).to.be.empty;
+    expect(specs.dataElements.all).to.be.empty;
+  });
+});
+
+describe('#Specifications.namespaces', () => {
+  it('should be empty at initialization', () => {
+    const specs = new mdl.Specifications();
+    expect(specs.namespaces.all).to.be.empty;
+  });
+
+  it('should add namespaces', () => {
+    const specs = new mdl.Specifications();
+    specs.namespaces.add(new mdl.Namespace('shr.test', 'A test namespace'));
+    specs.namespaces.add(new mdl.Namespace('shr.test.too', 'Another test namespace'));
+    expect(specs.namespaces.all).to.eql([
+      new mdl.Namespace('shr.test', 'A test namespace'),
+      new mdl.Namespace('shr.test.too', 'Another test namespace')
+    ]);
+  });
+
+  it('should find namespaces', () => {
+    const specs = new mdl.Specifications();
+    specs.namespaces.add(new mdl.Namespace('shr.test', 'A test namespace'));
+    specs.namespaces.add(new mdl.Namespace('shr.test.too', 'Another test namespace'));
+    expect(specs.namespaces.find('shr.test.too')).to.eql(
+      new mdl.Namespace('shr.test.too', 'Another test namespace')
+    );
+  });
+
+  it('should return undefined when finding namespaces that don\'t exist', () => {
+    const specs = new mdl.Specifications();
+    specs.namespaces.add(new mdl.Namespace('shr.test', 'A test namespace'));
+    specs.namespaces.add(new mdl.Namespace('shr.test.too', 'Another test namespace'));
+    expect(specs.namespaces.find('shr.test.three')).to.be.undefined;
+  });
+});
+
+describe('#Specifications.dataElements', () => {
+  it('should be empty at initialization', () => {
+    const specs = new mdl.Specifications();
+    expect(specs.dataElements.all).to.be.empty;
+  });
+
+  it('should add data elements', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    expect(specs.dataElements.all).to.eql([
+      new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)),
+      new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4))
+    ]);
+  });
+
+  it('should support retrieving entries only', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1)));
+    expect(specs.dataElements.entries).to.eql([
+      new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)),
+      new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1))
+    ]);
+  });
+
+  it('should support retrieving elements by namespace', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1)));
+    expect(specs.dataElements.byNamespace('shr.test')).to.eql([
+      new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)),
+      new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4))
+    ]);
+    expect(specs.dataElements.byNamespace('shr.test.too')).to.eql([
+      new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1))
+    ]);
+    expect(specs.dataElements.byNamespace('shr.test.three')).to.be.empty;
+  });
+
+  it('should support retrieving entries by namespace', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1)));
+    expect(specs.dataElements.entriesByNamespace('shr.test')).to.eql([
+      new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4))
+    ]);
+    expect(specs.dataElements.entriesByNamespace('shr.test.too')).to.eql([
+      new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1))
+    ]);
+    expect(specs.dataElements.entriesByNamespace('shr.test.three')).to.be.empty;
+  });
+
+  it('should find data elements', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    expect(specs.dataElements.find('shr.test', 'Two')).to.eql(
+      new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4))
+    );
+  });
+
+  it('should find data elements by identifier', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    expect(specs.dataElements.findByIdentifier(id('shr.test', 'Two'))).to.eql(
+      new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4))
+    );
+  });
+
+  it('should return undefined when finding data elements that don\'t exist', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    expect(specs.dataElements.find('shr.test', 'Three')).to.be.undefined;
+  });
+
+  it('should return active namespaces', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1)));
+    expect(specs.dataElements.namespaces).to.eql(['shr.test', 'shr.test.too']);
+  });
+
+  it('should collect grammar versions', () => {
+    const specs = new mdl.Specifications();
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'One'), true).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test', 'Two')).withGrammarVersion(v(4)));
+    specs.dataElements.add(new mdl.DataElement(id('shr.test.too', 'Three'), true).withGrammarVersion(v(4, 1)));
+    expect(specs.dataElements.grammarVersions).to.eql([ v(4), v(4, 1) ]);
+  });
+});
+
+function id(namespace, name) {
+  return new mdl.Identifier(namespace, name);
+}
+
+function v(major, minor, patch) {
+  return new mdl.Version(major, minor, patch);
+}


### PR DESCRIPTION
Mainly changes to support new grammar 4

Also adds a new Specifications class, and specific NamespaceSpecifications and DataElementSpecifications classes.  These serve as a good container for definitions, with functions for adding and looking up definitions.  This should be the main way specifications are passed around between tools (for example, the importer will return an instance of Specifications).