### PR TITLE
Fixed issue shr-models#8: No method of expressing constraint paths on…

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -954,10 +954,16 @@ class ChoiceValue extends Value {
 // constraint is applied without knowing the full context of the current data element (in the case of the importer).
 // If a data element is fully resolved, it should never contain an IncompleteValue.
 class IncompleteValue extends IdentifiableValue {
-  constructor(identifier) {
+  constructor(identifier, rawPath = []) {
     super(identifier);
+
+    //RawPath is the raw text version of the path to the inherited property. Necessary for json-export to be fully informed of constraint paths for inherited fields.
+    this._rawPath = rawPath;
   }
 
+  get rawPath() { return this._rawPath; }  
+  addRawPath(rPath) { this._rawPath.push(rPath); }  
+  
   clone() {
     const clone = new IncompleteValue();
     super._clonePropertiesTo(clone);


### PR DESCRIPTION
… inherited fields for Incomplete Values

Adds "RawPath" to IncompleteValue.
"RawPath is the raw text version of the path to the inherited property. Necessary for json-export to be fully informed of constraint paths for inherited fields."

Fixed issue:
https://github.com/standardhealth/shr-models/issues/8