### PR TITLE
Map to profiles

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -836,6 +836,13 @@ class Value {
     this.addConstraint(constraint);
     return this;
   }
+  // withConstraints is a convenience function for chaining
+  withConstraints(constraints) {
+    for (const constraint of constraints) {
+      this.addConstraint(constraint);
+    }
+    return this;
+  }
   get hasConstraints() {
     return this._constraints.length > 0;
   }

--- a/lib/models.js
+++ b/lib/models.js
@@ -470,10 +470,14 @@ class Identifier {
 
   get namespace() { return this._namespace; }
   get name() { return this._name; }
-  get fqn() { return this.isPrimitive ? this._name : `${this._namespace}.${this._name}`; }
+  get fqn() { return this.isPrimitive || this.isValueKeyWord ? this._name : `${this._namespace}.${this._name}`; }
 
   get isPrimitive() {
-    return this._namespace == PRIMITIVE_NS;
+    return this._namespace === PRIMITIVE_NS;
+  }
+
+  get isValueKeyWord() {
+    return this._namespace === '' && this._name === 'Value';
   }
 
   equals(other) {
@@ -505,7 +509,19 @@ class Cardinality {
   }
 
   get min() { return this._min; }
+  set min(min) { this._min = min; }
+  // withMin is a convenience function for chaining
+  withMin(min) {
+    this.min = min;
+    return this;
+  }
   get max() { return this._max; }
+  set max(max) { this._max = max; }
+  // withMin is a convenience function for chaining
+  withMax(max) {
+    this.max = max;
+    return this;
+  }
   get isMaxUnbounded() {
     return typeof this._max === 'undefined' || this._max == null;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
PR 1/5 in SHR Tool Support for Mapping to Profiles.

The `package.json` file will be updated w/ new version once this PR is approved (and _before_ it is merged).  Please review and approve, but do not merge.

This PR mainly adds support for being able to refer to `Value` so you can constrain it (e.g., `0..0 Value`).  It also exposes some setters for things we properties we need to modify in other tools.

