### PR TITLE
wip: Model inheritance

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -942,7 +942,15 @@ class Value {
     }
   }
 
-  _propsEquals(other) {
+  /**
+   * Check common properties for equality.
+   *
+   * @param other - the other value for comparison.
+   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
+   * @returns {boolean} if the common properties are equal.
+   * @protected
+   */
+  _propsEquals(other, ignoreInheritance = false) {
     if (!this.card) {
       if (other.card) {
         return false;
@@ -954,6 +962,10 @@ class Value {
       if (!this.card.equals(other.card)) {
         return false;
       }
+    }
+
+    if ((!ignoreInheritance) && (this.inheritance !== other.inheritance)) {
+      return false;
     }
 
     if (!this.hasConstraints) {
@@ -971,6 +983,7 @@ class Value {
         return false;
       }
     }
+
     return true;
   }
 }
@@ -1016,9 +1029,16 @@ class IdentifiableValue extends Value {
     clone._identifier = this._identifier.clone();
   }
 
-  equals(other) {
+  /**
+   * Check value for equality.
+   *
+   * @param other - the other value for comparison.
+   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
+   * @returns {boolean} if the values are equal.
+   */
+  equals(other, ignoreInheritance = false) {
     return (other instanceof IdentifiableValue) &&
-        this._propsEquals(other) &&
+        this._propsEquals(other, ignoreInheritance) &&
         this._identifier.equals(other.identifier);
   }
 
@@ -1038,8 +1058,15 @@ class RefValue extends IdentifiableValue {
     return clone;
   }
 
-  equals(other) {
-    return (other instanceof RefValue) && super.equals(other);
+  /**
+   * Check value for equality.
+   *
+   * @param other - the other value for comparison.
+   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
+   * @returns {boolean} if the values are equal.
+   */
+  equals(other, ignoreInheritance = false) {
+    return (other instanceof RefValue) && super.equals(other, ignoreInheritance);
   }
 
   toString() {
@@ -1084,8 +1111,15 @@ class ChoiceValue extends Value {
     return clone;
   }
 
-  equals(other) {
-    if ((!(other instanceof ChoiceValue)) || (!this._propsEquals(other))) {
+  /**
+   * Check value for equality.
+   *
+   * @param other - the other value for comparison.
+   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
+   * @returns {boolean} if the values are equal.
+   */
+  equals(other, ignoreInheritance = false) {
+    if ((!(other instanceof ChoiceValue)) || (!this._propsEquals(other, ignoreInheritance))) {
       return false;
     }
 
@@ -1100,7 +1134,7 @@ class ChoiceValue extends Value {
     }
 
     for (let i=0; i < this.options.length; i++) {
-      if (!this.options[i].equals(other.options[i])) {
+      if (!this.options[i].equals(other.options[i], ignoreInheritance)) {
         return false;
       }
     }
@@ -1135,8 +1169,15 @@ class IncompleteValue extends IdentifiableValue {
     return clone;
   }
 
-  equals(other) {
-    return (other instanceof IncompleteValue) && super.equals(other);
+  /**
+   * Check value for equality.
+   *
+   * @param other - the other value for comparison.
+   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
+   * @returns {boolean} if the values are equal.
+   */
+  equals(other, ignoreInheritance = false) {
+    return (other instanceof IncompleteValue) && super.equals(other, ignoreInheritance);
   }
 
   toString() {

--- a/lib/models.js
+++ b/lib/models.js
@@ -948,9 +948,12 @@ class Value {
    * @param other - the other value for comparison.
    * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
    * @returns {boolean} if the common properties are equal.
-   * @protected
    */
-  _propsEquals(other, ignoreInheritance = false) {
+  equals(other, ignoreInheritance = false) {
+    if (!other || (Object.getPrototypeOf(this) !== Object.getPrototypeOf(other))) {
+      return false;
+    }
+
     if (!this.card) {
       if (other.card) {
         return false;
@@ -1029,16 +1032,9 @@ class IdentifiableValue extends Value {
     clone._identifier = this._identifier.clone();
   }
 
-  /**
-   * Check value for equality.
-   *
-   * @param other - the other value for comparison.
-   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
-   * @returns {boolean} if the values are equal.
-   */
+  /** @inheritDoc */
   equals(other, ignoreInheritance = false) {
-    return (other instanceof IdentifiableValue) &&
-        this._propsEquals(other, ignoreInheritance) &&
+    return super.equals(other, ignoreInheritance) &&
         this._identifier.equals(other.identifier);
   }
 
@@ -1056,17 +1052,6 @@ class RefValue extends IdentifiableValue {
     const clone = new RefValue();
     super._clonePropertiesTo(clone);
     return clone;
-  }
-
-  /**
-   * Check value for equality.
-   *
-   * @param other - the other value for comparison.
-   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
-   * @returns {boolean} if the values are equal.
-   */
-  equals(other, ignoreInheritance = false) {
-    return (other instanceof RefValue) && super.equals(other, ignoreInheritance);
   }
 
   toString() {
@@ -1111,15 +1096,9 @@ class ChoiceValue extends Value {
     return clone;
   }
 
-  /**
-   * Check value for equality.
-   *
-   * @param other - the other value for comparison.
-   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
-   * @returns {boolean} if the values are equal.
-   */
+  /** @inheritDoc */
   equals(other, ignoreInheritance = false) {
-    if ((!(other instanceof ChoiceValue)) || (!this._propsEquals(other, ignoreInheritance))) {
+    if (!super.equals(other, ignoreInheritance)) {
       return false;
     }
 
@@ -1169,17 +1148,6 @@ class IncompleteValue extends IdentifiableValue {
     return clone;
   }
 
-  /**
-   * Check value for equality.
-   *
-   * @param other - the other value for comparison.
-   * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
-   * @returns {boolean} if the values are equal.
-   */
-  equals(other, ignoreInheritance = false) {
-    return (other instanceof IncompleteValue) && super.equals(other, ignoreInheritance);
-  }
-
   toString() {
     return `IncompleteValue<${this.identifier.fqn}>`;
   }
@@ -1195,9 +1163,11 @@ class TBD extends Value{
 
   /**
    * Check value for equality. This only checks that the other object is a TBD and that the text properties are ==.
+   * Because inheritance doesn't apply to TBD the ignoreInheritance parameter is unused.
    *
    * @param other - the other value for comparison
    * @returns {boolean} if the values are equal.
+   * @override
    */
   equals(other) {
     return (other instanceof TBD) && this._text == other.text;

--- a/lib/models.js
+++ b/lib/models.js
@@ -460,6 +460,11 @@ class Concept {
   clone() {
     return new Concept(this._system, this._code, this._display);
   }
+
+  equals(other) {
+    // TODO: Should display be required for equality?
+    return this._system == other.system && this._code == other.code && this._display == other.display;
+  }
 }
 
 class Identifier {
@@ -579,6 +584,25 @@ class Constraint {
       clone._path.push(p.clone());
     }
   }
+
+  _pathsAreEqual(other) {
+    if (!this.hasPath) {
+      return !other.hasPath;
+    }
+    if (!other.hasPath) {
+      return false;
+    }
+    if (this.path.length !== other.path.length) {
+      return false;
+    }
+
+    for (let i=0; i < this.path.length; i++) {
+      if (!this.path[i].equals(other.path[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 }
 
 // ValueSetConstraint only makes sense on a code or Coding type value
@@ -608,6 +632,13 @@ class ValueSetConstraint extends Constraint {
     this._clonePropertiesTo(clone);
     return clone;
   }
+
+  equals(other) {
+    return (other instanceof ValueSetConstraint) &&
+        this.bindingStrength == other.bindingStrength &&
+        this._valueSet == other.valueSet &&
+        this._pathsAreEqual(other);
+  }
 }
 
 // CodeConstraint only makes sense on a code or Coding type value
@@ -623,6 +654,12 @@ class CodeConstraint extends Constraint {
     const clone = new CodeConstraint(this._code.clone());
     this._clonePropertiesTo(clone);
     return clone;
+  }
+
+  equals(other) {
+    return (other instanceof CodeConstraint) &&
+        this._code.equals(other.code) &&
+        this._pathsAreEqual(other);
   }
 }
 
@@ -640,6 +677,12 @@ class IncludesCodeConstraint extends Constraint {
     this._clonePropertiesTo(clone);
     return clone;
   }
+
+  equals(other) {
+    return (other instanceof IncludesCodeConstraint) &&
+        this._code.equals(other.code) &&
+        this._pathsAreEqual(other);
+  }
 }
 
 // BooleanConstraint only makes sense on a boolean
@@ -655,6 +698,12 @@ class BooleanConstraint extends Constraint {
     const clone = new BooleanConstraint(this._value);
     this._clonePropertiesTo(clone);
     return clone;
+  }
+
+  equals(other) {
+    return (other instanceof BooleanConstraint) &&
+        this._value == other.value &&
+        this._pathsAreEqual(other);
   }
 }
 
@@ -683,6 +732,13 @@ class TypeConstraint extends Constraint {
     this._clonePropertiesTo(clone);
     return clone;
   }
+
+  equals(other) {
+    return (other instanceof TypeConstraint) &&
+        this._onValue == other.onValue &&
+        this._isA.equals(other.isA) &&
+        this._pathsAreEqual(other);
+  }
 }
 
 class IncludesTypeConstraint extends Constraint {
@@ -705,6 +761,14 @@ class IncludesTypeConstraint extends Constraint {
     this._clonePropertiesTo(clone);
     return clone;
   }
+
+  equals(other) {
+    return (other instanceof IncludesTypeConstraint) &&
+        this._onValue == other.onValue &&
+        this._isA.equals(other.isA) &&
+        this._card.equals(other.card) &&
+        this._pathsAreEqual(other);
+  }
 }
 
 class CardConstraint extends Constraint {
@@ -719,6 +783,12 @@ class CardConstraint extends Constraint {
     const clone = new CardConstraint(this._card.clone());
     this._clonePropertiesTo(clone);
     return clone;
+  }
+
+  equals(other) {
+    return (other instanceof CardConstraint) &&
+        this._card.equals(other.card) &&
+        this._pathsAreEqual(other);
   }
 }
 
@@ -858,6 +928,38 @@ class Value {
       clone._constraints.push(constraint.clone());
     }
   }
+
+  _propsEquals(other) {
+    if (!this.card) {
+      if (other.card) {
+        return false;
+      }
+    } else {
+      if (!other.card) {
+        return false;
+      }
+      if (!this.card.equals(other.card)) {
+        return false;
+      }
+    }
+
+    if (!this.hasConstraints) {
+      return !other.hasConstraints;
+    }
+    if (!other.hasConstraints) {
+      return false;
+    }
+    if (this.constraints.length !== other.constraints.length) {
+      return false;
+    }
+
+    for (let i=0; i < this.constraints.length; i++) {
+      if (!this.constraints[i].equals(other.constraints[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 }
 
 class IdentifiableValue extends Value {
@@ -901,6 +1003,12 @@ class IdentifiableValue extends Value {
     clone._identifier = this._identifier.clone();
   }
 
+  equals(other) {
+    return (other instanceof IdentifiableValue) &&
+        this._propsEquals(other) &&
+        this._identifier.equals(other.identifier);
+  }
+
   toString() {
     return `IdentifiableValue<${this.identifier.fqn}>`;
   }
@@ -915,6 +1023,10 @@ class RefValue extends IdentifiableValue {
     const clone = new RefValue();
     super._clonePropertiesTo(clone);
     return clone;
+  }
+
+  equals(other) {
+    return (other instanceof RefValue) && super.equals(other);
   }
 
   toString() {
@@ -959,6 +1071,29 @@ class ChoiceValue extends Value {
     return clone;
   }
 
+  equals(other) {
+    if ((!(other instanceof ChoiceValue)) || (!this._propsEquals(other))) {
+      return false;
+    }
+
+    if (!this.options) {
+      return !other.options;
+    }
+    if (!other.options) {
+      return false;
+    }
+    if (this.options.length !== other.options.length) {
+      return false;
+    }
+
+    for (let i=0; i < this.options.length; i++) {
+      if (!this.options[i].equals(other.options[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   toString() {
     let str = 'ChoiceValue<';
     for (let i=0; i < this._options.length; i++) {
@@ -985,6 +1120,10 @@ class IncompleteValue extends IdentifiableValue {
     const clone = new IncompleteValue();
     super._clonePropertiesTo(clone);
     return clone;
+  }
+
+  equals(other) {
+    return (other instanceof IncompleteValue) && super.equals(other);
   }
 
   toString() {

--- a/lib/models.js
+++ b/lib/models.js
@@ -1193,8 +1193,14 @@ class TBD extends Value{
 
   get text() { return this._text; }
 
+  /**
+   * Check value for equality. This only checks that the other object is a TBD and that the text properties are ==.
+   *
+   * @param other - the other value for comparison
+   * @returns {boolean} if the values are equal.
+   */
   equals(other) {
-    return this._text == other.text;
+    return (other instanceof TBD) && this._text == other.text;
   }
 
   clone() {

--- a/lib/models.js
+++ b/lib/models.js
@@ -948,11 +948,11 @@ class Value {
   }
 
   /**
-   * Check common properties for equality.
+   * Check values for equality.
    *
    * @param other - the other value for comparison.
    * @param {boolean} [ignoreInheritance=false] - if the inheritance property should be ignored.
-   * @returns {boolean} if the common properties are equal.
+   * @returns {boolean} if the values are equal.
    */
   equals(other, ignoreInheritance = false) {
     if (!other || (Object.getPrototypeOf(this) !== Object.getPrototypeOf(other))) {

--- a/lib/models.js
+++ b/lib/models.js
@@ -1166,6 +1166,10 @@ class TBD extends Value{
 
   get text() { return this._text; }
 
+  set text(text) {
+    this._text = text;
+  }
+
   /**
    * Check value for equality. This only checks that the other object is a TBD and that the text properties are ==.
    * Because inheritance doesn't apply to TBD the ignoreInheritance parameter is unused.

--- a/lib/models.js
+++ b/lib/models.js
@@ -461,9 +461,14 @@ class Concept {
     return new Concept(this._system, this._code, this._display);
   }
 
+  /**
+   * Check concepts for equality. Note that this ignores the display property.
+   *
+   * @param other - the other concept for comparison.
+   * @returns {boolean} if the system and code are equal.
+   */
   equals(other) {
-    // TODO: Should display be required for equality?
-    return this._system == other.system && this._code == other.code && this._display == other.display;
+    return (other instanceof Concept) && this._system == other.system && this._code == other.code;
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -920,12 +920,25 @@ class Value {
     return new ConstraintsFilter(this._constraints);
   }
 
+  get inheritance() { return this._inheritance; }
+  set inheritance(inheritance) {
+    this._inheritance = inheritance;
+  }
+  // withInheritance is a convenience function for chaining
+  withInheritance(inheritance) {
+    this.inheritance = inheritance;
+    return this;
+  }
+
   _clonePropertiesTo(clone) {
     if (this._card) {
       clone._card = this._card.clone();
     }
     for (const constraint of this._constraints) {
       clone._constraints.push(constraint.clone());
+    }
+    if (this._inheritance) {
+      clone._inheritance = this.inheritance;
     }
   }
 
@@ -1661,4 +1674,8 @@ const PRIMITIVE_NS = 'primitive';
 const PRIMITIVES = ['boolean', 'integer', 'decimal', 'unsignedInt', 'positiveInt', 'string', 'markdown', 'code', 'id',
   'oid', 'uri', 'base64Binary', 'date', 'dateTime', 'instant', 'time', 'xhtml'];
 
-module.exports = {Specifications, NamespaceSpecifications, DataElementSpecifications, Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, IncludesTypeConstraint, CardConstraint, ValueSet, ValueSetIncludesCodeRule, ValueSetIncludesDescendentsRule, ValueSetExcludesDescendentsRule, ValueSetIncludesFromCodeSystemRule, ValueSetIncludesFromCodeRule, CodeSystem, ElementMapping, FieldMappingRule, CardinalityMappingRule, FixedValueMappingRule, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE};
+// Inheritance constants
+const INHERITED = 'inherited';
+const OVERRIDDEN = 'overridden'
+
+module.exports = {Specifications, NamespaceSpecifications, DataElementSpecifications, Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, IncludesTypeConstraint, CardConstraint, ValueSet, ValueSetIncludesCodeRule, ValueSetIncludesDescendentsRule, ValueSetExcludesDescendentsRule, ValueSetIncludesFromCodeSystemRule, ValueSetIncludesFromCodeRule, CodeSystem, ElementMapping, FieldMappingRule, CardinalityMappingRule, FixedValueMappingRule, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE, INHERITED, OVERRIDDEN};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.1.0",
+  "version": "5.2.0-beta.1",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -98,7 +98,8 @@ describe('#Value', () => {
     const val = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
       .withMinMax(0,1)
       .withConstraint(new mdl.CardConstraint(new mdl.Cardinality(1,1)))
-      .withConstraint(new mdl.TypeConstraint(new mdl.Identifier('shr.test', 'SonOfFoo')));
+      .withConstraint(new mdl.TypeConstraint(new mdl.Identifier('shr.test', 'SonOfFoo')))
+      .withInheritance(mdl.INHERITED);
     const val2 = val.clone();
     // Ensure they're not the same instance ('equal'), but they have equal values ('eql')
     expect(val2).not.to.equal(val);
@@ -109,6 +110,22 @@ describe('#Value', () => {
     expect(val2.constraints[0]).not.to.equal(val.constraints[0]);
     expect(val2.constraints[1]).not.to.equal(val.constraints[1]);
     expect(val2.constraints).to.eql(val.constraints);
+    expect(val2.inheritance).to.equal(val.inheritance);
+    expect(val2.equals(val)).to.be.true;
+  });
+
+  it('should ignore inheritance during equality when asked', () => {
+    const val = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
+      .withMinMax(0,1)
+      .withConstraint(new mdl.CardConstraint(new mdl.Cardinality(1,1)))
+      .withConstraint(new mdl.TypeConstraint(new mdl.Identifier('shr.test', 'SonOfFoo')))
+      .withInheritance(mdl.INHERITED);
+
+    const val2 = val.clone();
+    val2.inheritance = mdl.OVERRIDDEN;
+
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
   });
 });
 
@@ -138,6 +155,7 @@ describe('#IdentifiableValue', () => {
     expect(val2).to.eql(val);
     expect(val2.identifier).not.to.equal(val.identifier);
     expect(val2.identifier).to.eql(val.identifier);
+    expect(val2.equals(val)).to.be.true;
   });
 
   it('should toString its class and identifier', () => {
@@ -145,6 +163,15 @@ describe('#IdentifiableValue', () => {
       .withMinMax(1,1);
     const str = val.toString();
     expect(str).to.equal('IdentifiableValue<shr.test.Foo>');
+  });
+
+  it('should ignore inheritance during equality when asked', () => {
+    const val = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    const val2 = val.clone();
+    val2.inheritance = mdl.INHERITED;
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
   });
 });
 
@@ -174,6 +201,7 @@ describe('#RefValue', () => {
     expect(val2).to.eql(val);
     expect(val2.identifier).not.to.equal(val.identifier);
     expect(val2.identifier).to.eql(val.identifier);
+    expect(val2.equals(val)).to.be.true;
   });
 
   it('should toString its class and identifier', () => {
@@ -181,6 +209,24 @@ describe('#RefValue', () => {
       .withMinMax(1,1);
     const str = val.toString();
     expect(str).to.equal('RefValue<shr.test.Foo>');
+  });
+
+  it('should not equal a similar IndentifiableValue', () => {
+    const val = new mdl.RefValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    const ival = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    expect(val.equals(ival)).to.be.false;
+    expect(ival.equals(val)).to.be.false;
+  });
+
+  it('should ignore inheritance during equality when asked', () => {
+    const val = new mdl.RefValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    const val2 = val.clone();
+    val.inheritance = mdl.OVERRIDDEN;
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
   });
 });
 
@@ -206,12 +252,16 @@ describe('#ChoiceValue', () => {
     ]);
   });
 
-  it('should correctly clone its properties', () => {
+  function cloneValues() {
     const val = new mdl.ChoiceValue()
-      .withMinMax(1,1)
-      .withOption(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo')).withMinMax(1,1))
-      .withOption(new mdl.RefValue(new mdl.Identifier('shr.test', 'Bar')).withMinMax(0,1));
+        .withMinMax(1,1)
+        .withOption(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo')).withMinMax(1,1))
+        .withOption(new mdl.RefValue(new mdl.Identifier('shr.test', 'Bar')).withMinMax(0,1));
     const val2 = val.clone();
+    return {val, val2};
+  }
+  it('should correctly clone its properties', () => {
+    const {val, val2} = cloneValues();
     // Ensure they're not the same instance ('equal'), but they have equal values ('eql')
     expect(val2).not.to.equal(val);
     expect(val2).to.eql(val);
@@ -219,6 +269,7 @@ describe('#ChoiceValue', () => {
     expect(val2.options[0]).not.to.equal(val.options[0]);
     expect(val2.options[1]).not.to.equal(val.options[1]);
     expect(val2.options).to.eql(val.options);
+    expect(val2.equals(val)).to.be.true;
   });
 
   it('should toString its class and identifier', () => {
@@ -228,6 +279,23 @@ describe('#ChoiceValue', () => {
       .withOption(new mdl.RefValue(new mdl.Identifier('shr.test', 'Bar')).withMinMax(0,1));
     const str = val.toString();
     expect(str).to.equal('ChoiceValue<IdentifiableValue<shr.test.Foo>|RefValue<shr.test.Bar>>');
+  });
+
+  it('should ignore inheritance during equality when asked', () => {
+    const {val, val2} = cloneValues();
+    val.inheritance = mdl.INHERITED;
+    val2.inheritance = mdl.OVERRIDDEN;
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
+    val2.inheritance = mdl.INHERITED;
+    expect(val2.equals(val)).to.be.true;
+
+    val.options[0].inheritance = mdl.INHERITED;
+    val2.options[0].inheritance = mdl.OVERRIDDEN;
+    val2.options[1].inheritance = mdl.INHERITED;
+
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
   });
 });
 
@@ -255,6 +323,24 @@ describe('#IncompleteValue', () => {
     const str = val.toString();
     expect(str).to.equal('IncompleteValue<shr.test.Foo>');
   });
+
+  it('should not equal a similar IndentifiableValue', () => {
+    const val = new mdl.IncompleteValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    const ival = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    expect(val.equals(ival)).to.be.false;
+    expect(ival.equals(val)).to.be.false;
+  });
+
+  it('should ignore inheritance during equality when asked', () => {
+    const val = new mdl.IncompleteValue(new mdl.Identifier('shr.test', 'Foo'))
+        .withMinMax(1,1);
+    const val2 = val.clone();
+    val2.inheritance = mdl.INHERITED;
+    expect(val2.equals(val)).to.be.false;
+    expect(val2.equals(val, true)).to.be.true;
+  });
 });
 
 describe('#TBD', () => {
@@ -270,6 +356,11 @@ describe('#TBD', () => {
     expect(val2).not.to.equal(val);
     expect(val2).to.eql(val);
     expect(val2.text).to.equal(val.text);
+    expect(val2.equals(val)).to.be.true;
+    val.inheritance = mdl.OVERRIDDEN;
+    val2.inheritance = mdl.INHERITED;
+    expect(val2.equals(val)).to.be.true;
+    expect(val2.equals(val, false)).to.be.true;
   });
 
   it('should toString its class and identifier', () => {

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -1,6 +1,23 @@
 const {expect} = require('chai');
 const mdl = require('../index');
 
+describe('#Concept', () => {
+  it('should correctly calculate equality and handling cloning.', () => {
+    const code = new mdl.Concept('urn:x-test:some/namespace', '12345', 'My first code!');
+    const code2 = code.clone();
+    expect(code2.system).to.eql(code.system);
+    expect(code2.code).to.eql(code.code);
+    expect(code2.display).to.eql(code.display);
+    expect(code2.equals(code)).to.be.true;
+
+    code2.display = 'Another name for the code.'
+    expect(code2.equals(code)).to.be.true;
+
+    code2.code = '6789'
+    expect(code2.equals(code)).to.be.false;
+  });
+})
+
 describe('#Value', () => {
   it('should correctly set and get cardinalities', () => {
     // Need to use an subclass of Value to get an instance


### PR DESCRIPTION
This change is in support of tracking inheritance in shr-expand. This adds equality tests to constraints and an additional field for tracking inheritance to the data element class.

There are some unresolved issues including a lack of unit tests (although there are tests in shr-json-schema-export that do exercise this functionality) and data element's equals() doesn't consider the inheritance field when determining equality.