### PR TITLE
Fix IncludesTypeConstraint equals function

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -1740,6 +1740,6 @@ const PRIMITIVES = ['boolean', 'integer', 'decimal', 'unsignedInt', 'positiveInt
 
 // Inheritance constants
 const INHERITED = 'inherited';
-const OVERRIDDEN = 'overridden'
+const OVERRIDDEN = 'overridden';
 
 module.exports = {Specifications, NamespaceSpecifications, DataElementSpecifications, Namespace, DataElement, Concept, Identifier, PrimitiveIdentifier, Value, IdentifiableValue, RefValue, ChoiceValue, IncompleteValue, TBD, ConstraintsFilter, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, IncludesTypeConstraint, CardConstraint, ValueSet, ValueSetIncludesCodeRule, ValueSetIncludesDescendentsRule, ValueSetExcludesDescendentsRule, ValueSetIncludesFromCodeSystemRule, ValueSetIncludesFromCodeRule, CodeSystem, ElementMapping, FieldMappingRule, CardinalityMappingRule, FixedValueMappingRule, Version, PRIMITIVE_NS, PRIMITIVES, VERSION, GRAMMAR_VERSION, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE, INHERITED, OVERRIDDEN, MODELS_INFO, sanityCheckModules};

--- a/lib/models.js
+++ b/lib/models.js
@@ -807,7 +807,7 @@ class IncludesTypeConstraint extends Constraint {
 
   equals(other) {
     return (other instanceof IncludesTypeConstraint) &&
-        this._onValue == other.onValue &&
+        this._isOnValue == other._isOnValue &&
         this._isA.equals(other.isA) &&
         this._card.equals(other.card) &&
         this._pathsAreEqual(other);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fix the IncludesTypeConstraint equals function to reference the correct private property for isOnValue.

NOTE: The get/set "isOnValue" is inconsistent with type's "onValue".  Ideally they'd have the same name, but for now we're just fixing the bug.