### PR TITLE
Constraints filter on value fix

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -853,11 +853,11 @@ class ConstraintsFilter {
   }
 
   get own() {
-    return new ConstraintsFilter(this._constraints.filter(c => c.path.length == 0));
+    return new ConstraintsFilter(this._constraints.filter(c => c.path.length == 0 && (!c.onValue) && (!c.isOnValue)));
   }
 
   get child() {
-    return new ConstraintsFilter(this._constraints.filter(c => c.path.length > 0));
+    return new ConstraintsFilter(this._constraints.filter(c => c.path.length > 0 || c.onValue || c.isOnValue));
   }
 
   get valueSet() {

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -314,6 +314,21 @@ describe('#ChoiceValue', () => {
     expect(val2.equals(val)).to.be.false;
     expect(val2.equals(val, true)).to.be.true;
   });
+
+  it('should be properly identified as the effective value on a constrained element', () => {
+    // TODO: Perhaps this should be moved to a separate suite for ConstraintsFilter.
+    // TODO: We should also test for IncludesTypeConstraint's isOnValue as well.
+    const base = new mdl.DataElement(new mdl.Identifier('shr.test', 'ChoiceValue'))
+      .withValue(new mdl.ChoiceValue()
+        .withMinMax(1,1)
+        .withOption(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo')).withMinMax(1,1))
+        .withOption(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Bar')).withMinMax(1,1)));
+    const consumer = new mdl.DataElement(new mdl.Identifier('shr.test', 'Consumer'))
+      .withValue(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'ChoiceValue'))
+        .withConstraint(new mdl.TypeConstraint(new mdl.Identifier('shr.test', 'Bar')).withOnValue(true)));
+
+    expect(consumer.value.effectiveIdentifier.equals(new mdl.Identifier('shr.test', 'ChoiceValue'))).to.be.true;
+  });
 });
 
 describe('#IncompleteValue', () => {


### PR DESCRIPTION
This corrects the `own()` and `child()` methods on `ConstraintsFilter`.

The unit tests aren't great here. ConstraintsFilter has no existing test suite of its own, although it may be tested indirectly. This PR adds a unit test for `effectiveIdentifier()` which exercises `own()`. `child()` remains untested, but there is no code in the models package that uses it directly.

I've verified that these changes don't break the unit tests in `shr-expand`. A run against shr-cli against shr_spec#shimi doesn't cause any errors. There are some changes related to gestationaltemporalcontext vs generalizedtemporalcontext on shr.lifehistory.PrenatalExposure in the FHIR exporter, but I'm not sure if that is due to other bugs in either the expander or the FHIR exporter (or perhaps their assumptions about how `effectiveIdentifer()` used to work).