### PR TITLE
Added user-friendly Logger String

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -1032,10 +1032,6 @@ class Value {
 
     return true;
   }
-
-  toLoggerString() {
-    return this.toString();
-  }
 }
 
 class IdentifiableValue extends Value {
@@ -1086,10 +1082,6 @@ class IdentifiableValue extends Value {
   }
 
   toString() {
-    return `IdentifiableValue<${this.identifier.fqn}>`;
-  }
-
-  toLoggerString() {
     return this.identifier.name;
   }
 }
@@ -1106,10 +1098,6 @@ class RefValue extends IdentifiableValue {
   }
 
   toString() {
-    return `RefValue<${this.identifier.fqn}>`;
-  }
-
-  toLoggerString() {
     return `ref(${this.identifier.fqn})`
   }
 }
@@ -1176,28 +1164,15 @@ class ChoiceValue extends Value {
   }
 
   toString() {
-    let str = 'ChoiceValue<';
-    for (let i=0; i < this._options.length; i++) {
-      str += this._options[i].toString();
-      if ((i+1) < this._options.length) {
-        str += '|';
-      }
-    }
-    str += '>';
-    return str;
-  }
-
-  toLoggerString() {
     let str = 'Choice(';
     for (let i=0; i < this._options.length; i++) {
-      str += this._options[i].toLoggerString();
+      str += this._options[i].toString();
       if ((i+1) < this._options.length) {
         str += ', ';
       }
     }
     str += ')';
     return str;
-
   }
 }
 
@@ -1252,11 +1227,7 @@ class TBD extends Value{
   }
 
   toString() {
-    return this._text ? `TBD<${this._text}>` : 'TBD';
-  }
-
-  toLoggerString() {
-    return this.toString();
+    return this._text ? `TBD(${this._text})` : 'TBD';
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -1098,7 +1098,7 @@ class RefValue extends IdentifiableValue {
   }
 
   toString() {
-    return `ref(${this.identifier.fqn})`
+    return `ref(${this.identifier.name})`
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -1032,6 +1032,10 @@ class Value {
 
     return true;
   }
+
+  toLoggerString() {
+    return this.toString();
+  }
 }
 
 class IdentifiableValue extends Value {
@@ -1084,6 +1088,10 @@ class IdentifiableValue extends Value {
   toString() {
     return `IdentifiableValue<${this.identifier.fqn}>`;
   }
+
+  toLoggerString() {
+    return this.identifier.name;
+  }
 }
 
 class RefValue extends IdentifiableValue {
@@ -1099,6 +1107,10 @@ class RefValue extends IdentifiableValue {
 
   toString() {
     return `RefValue<${this.identifier.fqn}>`;
+  }
+
+  toLoggerString() {
+    return `ref(${this.identifier.fqn})`
   }
 }
 
@@ -1174,6 +1186,19 @@ class ChoiceValue extends Value {
     str += '>';
     return str;
   }
+
+  toLoggerString() {
+    let str = 'Choice(';
+    for (let i=0; i < this._options.length; i++) {
+      str += this._options[i].toLoggerString();
+      if ((i+1) < this._options.length) {
+        str += ', ';
+      }
+    }
+    str += ')';
+    return str;
+
+  }
 }
 
 // IncompleteValue provides a place to put constraints when the full definition of the thing being constrained is
@@ -1228,6 +1253,10 @@ class TBD extends Value{
 
   toString() {
     return this._text ? `TBD<${this._text}>` : 'TBD';
+  }
+
+  toLoggerString() {
+    return this.toString();
   }
 }
 

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -179,7 +179,7 @@ describe('#IdentifiableValue', () => {
     const val = new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo'))
       .withMinMax(1,1);
     const str = val.toString();
-    expect(str).to.equal('IdentifiableValue<shr.test.Foo>');
+    expect(str).to.equal('Foo');
   });
 
   it('should ignore inheritance during equality when asked', () => {
@@ -225,7 +225,7 @@ describe('#RefValue', () => {
     const val = new mdl.RefValue(new mdl.Identifier('shr.test', 'Foo'))
       .withMinMax(1,1);
     const str = val.toString();
-    expect(str).to.equal('RefValue<shr.test.Foo>');
+    expect(str).to.equal('ref(Foo)');
   });
 
   it('should not equal a similar IndentifiableValue', () => {
@@ -295,7 +295,7 @@ describe('#ChoiceValue', () => {
       .withOption(new mdl.IdentifiableValue(new mdl.Identifier('shr.test', 'Foo')).withMinMax(1,1))
       .withOption(new mdl.RefValue(new mdl.Identifier('shr.test', 'Bar')).withMinMax(0,1));
     const str = val.toString();
-    expect(str).to.equal('ChoiceValue<IdentifiableValue<shr.test.Foo>|RefValue<shr.test.Bar>>');
+    expect(str).to.equal('Choice(Foo, ref(Bar))');
   });
 
   it('should ignore inheritance during equality when asked', () => {
@@ -383,6 +383,6 @@ describe('#TBD', () => {
   it('should toString its class and identifier', () => {
     const val = new mdl.TBD('To Be Defined').withMinMax(1,1);
     const str = val.toString();
-    expect(str).to.equal('TBD<To Be Defined>');
+    expect(str).to.equal('TBD(To Be Defined)');
   });
 });


### PR DESCRIPTION
This is a more readable option for choice values in errors (in response to feedback from Mark).

Turns:
> [19:25:20.965Z] ERROR shr: No cardinality found for field: ChoiceValue<IdentifiableValue<shr.core.CodeableConcept>|RefValue<shr.core.Range>|IdentifiableValue<shr.core.Quantity>>. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)

into:

> [19:19:23.316Z] ERROR shr: No cardinality found for field Choice(CodeableConcept, Range, Quantity) in ResultTargeted. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)

(with the addition of some base class tracking improvements by @cmoesel).