### PR TITLE
effectiveCardinality should account for IncludesTypeConstraints

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -930,12 +930,12 @@ class Value {
   }
 
   get effectiveCard() {
-    let eCard = this.card;
+    let eCard = this.card.clone();
 
     // First check if there is a cardinality constraint and use it if it's there
     const cardConstraints = this.constraintsFilter.own.card.constraints;
     if (cardConstraints.length > 0) {
-      eCard = cardConstraints[cardConstraints.length - 1].card;
+      eCard = cardConstraints[cardConstraints.length - 1].card.clone();
     }
 
     // Now look at includes type constraints, because any that have lower card > 0 may affect this card

--- a/lib/models.js
+++ b/lib/models.js
@@ -930,11 +930,24 @@ class Value {
   }
 
   get effectiveCard() {
+    let eCard = this.card;
+
+    // First check if there is a cardinality constraint and use it if it's there
     const cardConstraints = this.constraintsFilter.own.card.constraints;
     if (cardConstraints.length > 0) {
-      return cardConstraints[cardConstraints.length - 1].card;
+      eCard = cardConstraints[cardConstraints.length - 1].card;
     }
-    return this.card;
+
+    // Now look at includes type constraints, because any that have lower card > 0 may affect this card
+    let sumOfIncludesTypeMins = 0;
+    for (const itConstraint of this.constraintsFilter.own.includesType.constraints) {
+      sumOfIncludesTypeMins += itConstraint.card.min;
+    }
+    if (sumOfIncludesTypeMins > eCard.min) {
+      eCard.min = sumOfIncludesTypeMins;
+    }
+
+    return eCard;
   }
 
   get constraints() { return this._constraints; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The effective cardinality already took into account CardConstraints -- but did not take into account IncludesTypeConstraints.  Since these constraints have their own cardinalities, they can affect the cardinality of the element to which they are applied.

For example, if we have:
```
0..* Foo
  includes 1..1 Bar
```
then since Foo must contain at least one Bar, Foo's _effective_ lower cardinality is actually 1.

This PR takes that into account when determining effectiveCardinality.

This is one part of the fix for standardhealth/shr-fhir-export#72.