### PR TITLE
CIMCORE/canonical json updates

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -37,8 +37,19 @@ function sanityCheckModules(modelInfoMap) {
   }
 }
 
+function clearEmptyFields(object, iteratively = false) {
+    Object.keys(object).forEach((key) => {
+      if (object[key] == null) delete object[key]; else
+      if (object[key] instanceof Array && object[key].length == 0) delete object[key]; else
+      if (object[key] instanceof Object) {
+        if (Object.keys(object[key]).length && iteratively) clearEmptyFields(object[key], true);
+        if (!Object.keys(object[key]).length) delete object[key];
+      }
+  })
+}
+
 class Specifications {
-//pragma region collapse
+ 
   constructor() {
     this._namespaces = new NamespaceSpecifications();
     this._dataElements = new DataElementSpecifications();
@@ -55,7 +66,7 @@ class Specifications {
 }
 
 class NamespaceSpecifications {
-//pragma region collapse
+ 
   constructor() {
     this._nsMap = new Map();
   }
@@ -72,7 +83,7 @@ class NamespaceSpecifications {
 }
 
 class DataElementSpecifications {
-//pragma region collapse
+ 
   constructor() {
     this._nsMap = new Map();
     this._grammarVersions = new Map();
@@ -128,7 +139,7 @@ class DataElementSpecifications {
     return this.find(identifier.namespace, identifier.name);
   }
 
-//pragma endregion collapse
+ 
 
   // toJSON() {
   
@@ -136,7 +147,7 @@ class DataElementSpecifications {
 }
 
 class ValueSetSpecifications {
-//pragma region collapse
+ 
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -186,7 +197,7 @@ class ValueSetSpecifications {
 }
 
 class CodeSystemSpecifications {
-//pragma region collapse
+ 
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -236,7 +247,7 @@ class CodeSystemSpecifications {
 }
 
 class MapSpecifications {
-//pragma region collapse
+ 
   constructor() {
     this._targetMap = new Map();
     this._grammarVersions = new Map();
@@ -293,7 +304,7 @@ class MapSpecifications {
 }
 
 class TargetMapSpecifications {
-//pragma region collapse
+ 
   constructor(target) {
     this._target = target;
     this._nsMap = new Map();
@@ -342,7 +353,7 @@ class TargetMapSpecifications {
 }
 
 class Namespace {
-//pragma region collapse
+ 
   constructor(namespace, description) {
     this._namespace = namespace; // string
     this._description = description; // string
@@ -365,19 +376,16 @@ class Namespace {
     return new Namespace(this._namespace, this._description);
   }
 
-//pragma endregion
-
   toJSON() {
     return {
       "name": this.namespace,
       "description": this.description,
-      "external_dependencies" : []
+      "external_dependencies" : undefined
     }
   }  
 }
 
 class DataElement {
-//pragma region foo
   constructor(identifier, isEntry=false, isAbstract=false) {
     this._identifier = identifier; // Identifier
     this._isEntry = isEntry; // boolean
@@ -504,32 +512,34 @@ class DataElement {
     }
     return clone;
   }
-//pragma endregion foo
 
   toJSON() {
-    var outputJSON = {
-      "name": this.identifier.name,
-      "namespace": this.identifier.namespace,
-      "isEntry": this.isEntry,
-      "isAbstract": this.isAbstract,
-      "description": this.description,
-      "concepts": this.concepts.map(c => c.toJSON()),
-      "hierarchy": this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
-      "basedOn": this.basedOn.map(b => b.fqn),
-      "value": {},
-      "fields": {},
+    var output = {
+      "name":         this.identifier.name,
+      "namespace":    this.identifier.namespace,
+      "fqn":          this.identifier.fqn,
+      "isEntry":      this.isEntry,
+      "isAbstract":   this.isAbstract,
+      "description":  this.description,
+      "concepts":     this.concepts.map(c => c.toJSON()),
+      "hierarchy":    this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
+      "basedOn":      this.basedOn.map(b => b.fqn || b.toString()),
+      "value":        {},
+      "fields":       [],
     };
 
-    outputJSON.fields = this._fields.reduce((out, f) => Object.assign(out, f.toJSON()), {})
-    outputJSON.value = this.value != null ? this.value.toJSON() : "undefined";
-
-    return outputJSON;
+    output.value  = this.value != null ? this.value.toJSON() : undefined;
+    output.fields = this._fields.map(f => f.toJSON());
+    
+    clearEmptyFields(output, true)
+    
+    return output;
   }
 }
 
 class Concept {
 
-//pragma region collapse
+ 
 constructor(system, code, display) {
     this._system = system;
     this._code = code;
@@ -576,7 +586,7 @@ constructor(system, code, display) {
 }
 
 class Identifier {
-//pragma region collapse
+ 
   constructor(namespace, name) {
     this._namespace = namespace; // string
     this._name = name; // string
@@ -611,14 +621,14 @@ class Identifier {
 }
 
 class PrimitiveIdentifier extends Identifier {
-//pragma region collapse
+ 
   constructor(name) {
     super(PRIMITIVE_NS, name);
   }
 }
 
 class Cardinality {
-//pragma region collapse
+ 
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
@@ -679,7 +689,7 @@ class Cardinality {
       "max": this._max
     };
 
-    if (this._history.length > 0) {
+    if (this._history && this._history.length > 0) {
       out["history"] = this._history.map(h => ({
         "source": h["source"],
         "min": h._min,
@@ -693,7 +703,7 @@ class Cardinality {
 }
 
 class Constraint {
-//pragma region collapse
+ 
   constructor(path = []) {
     this._path = path;
   }
@@ -749,7 +759,7 @@ class Constraint {
 
 // ValueSetConstraint only makes sense on a code or Coding type value
 class ValueSetConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(valueSet, path, bindingStrength=REQUIRED) {
     super(path);
     this._valueSet = valueSet;
@@ -785,15 +795,15 @@ class ValueSetConstraint extends Constraint {
 
   toJSON() {
     var constraint = super.toJSON();
-    constraint["value_set"] = this._valueSet;
-    constraint["binding_strength"] = this._bindingStrength
+    constraint["valueSet"] = this._valueSet;
+    constraint["bindingStrength"] = this._bindingStrength
     return constraint;  
   }
 }
 
 // CodeConstraint only makes sense on a code or Coding type value
 class CodeConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -827,7 +837,7 @@ class CodeConstraint extends Constraint {
 
 // IncludesCodeConstraint only makes sense on an array of code or Coding
 class IncludesCodeConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -859,7 +869,7 @@ class IncludesCodeConstraint extends Constraint {
 
 // BooleanConstraint only makes sense on a boolean
 class BooleanConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(value, path) {
     super(path);
     this._value = value;
@@ -889,7 +899,7 @@ class BooleanConstraint extends Constraint {
 }
 
 class TypeConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(isA, path, onValue = false) {
     super(path);
     this._isA = isA;
@@ -924,7 +934,7 @@ class TypeConstraint extends Constraint {
 
   toJSON() {
     var constraint = super.toJSON();
-    constraint["isA"] = {
+    constraint["subtype"] = {
       "namespace": this._isA.namespace,
       "name": this._isA.name
     }
@@ -934,7 +944,7 @@ class TypeConstraint extends Constraint {
 }
 
 class IncludesTypeConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(isA, card, path, isOnValue=false) {
     super(path);
     this._isA = isA;
@@ -976,7 +986,7 @@ class IncludesTypeConstraint extends Constraint {
 }
 
 class CardConstraint extends Constraint {
-//pragma region collapse
+ 
   constructor(card, path) {
     super(path);
     this._card = card;
@@ -1004,7 +1014,7 @@ class CardConstraint extends Constraint {
 }
 
 class ConstraintsFilter {
-//pragma region collapse
+ 
   constructor(constraints = []) {
     this._constraints = constraints;
   }
@@ -1074,7 +1084,7 @@ class ConstraintsFilter {
 }
 
 class Value {
-//pragma region collapse
+ 
   constructor() {
     this._constraints = [];
     this._inheritance = undefined;
@@ -1222,72 +1232,61 @@ class Value {
 
     return true;
   }
-//pragma endregion collapse
+ 
   toJSON() {
-    
     let constraints = this._constraints.reduce((out, c, i, e) => {
       let key = c.constructor.name.replace(/constraint/i, '').replace(/^[a-zA-Z]/, (s) => s.toLowerCase());
-      let cst = c.toJSON(); 
+      let cst = c.toJSON();
 
-      var iterAdder = (constraint, outputDict, skipCard=false) => {
-        let arrConstraints  = ['includesType', 'includesCode'];
-        let dicConstraints  = ['type', 'valueSet', 'card'];
-        let valConstraints  = ['boolean', 'code'];
-        
-        (skipCard) ? dicConstraints.pop() : null;
-  
-        (arrConstraints.includes(key))  ? (outputDict[key] == null ? outputDict[key] = [] : true) && outputDict[key].push(cst)      :
-        (dicConstraints.includes(key))  ? outputDict[key] = cst          :
-        (valConstraints.includes(key))  ? outputDict['fixedValue'] = cst : null;  
-      }
-
-      if (c.path.length == 0) {
-        iterAdder(c, out, true)
-      } else if (c.path.length > 0) {
-        var currentSubField = out;
-        c.path.forEach((subC) => {
-          if (currentSubField['subpaths']           == null)  { currentSubField['subpaths'] = {} }
-          if (currentSubField['subpaths'][subC.fqn] == null)  { currentSubField['subpaths'][subC.fqn] = {} }
-          currentSubField = currentSubField['subpaths'][subC.fqn];
-          
-          iterAdder(subC, currentSubField)
-        })
-      }
+      let arrConstraints  = ['includesType', 'includesCode'];
+      let dicConstraints  = ['type', 'valueSet', 'card'];
+      let valConstraints  = ['boolean', 'code'];
       
-      return out;
-    }, {
-      // "type":         {},
-      // "valueSet":     {},
-      // "fixedValue":   {},
-      // "includesType": [],
-      // "includesCode": [],
-      // "subpaths":     []
+      var addToPath = (outputDict, skipCard=false) => {
+        if (skipCard && key == 'card') return;
+
+        if (arrConstraints.includes(key)) (outputDict[key] == null ? outputDict[key] = [] : true) && outputDict[key].push(cst) ; else
+        if (dicConstraints.includes(key))  outputDict[key] = cst ; else
+        if (valConstraints.includes(key))  outputDict['fixedValue'] = cst;    
       }
+
+      if (c.path.length == 0) addToPath(out, true); else
+      if (c.path.length  > 0) {
+        let currentSubField = out;
+        c.path.forEach((subP) => {
+          if (currentSubField['subpaths']           == null) currentSubField['subpaths']           = {};
+          if (currentSubField['subpaths'][subP.fqn] == null) currentSubField['subpaths'][subP.fqn] = {};
+          currentSubField = currentSubField['subpaths'][subP.fqn]; 
+          addToPath(currentSubField)
+        })
+      }   
+
+      return out;
+    }, {}
     );
 
-    // Object.keys(constraints).forEach((key) => (constraints[key].length == 0 || !Object.keys(constraints[key]).length) && delete constraints[key]); //optionally: clear empty constraints
-
     let card = (this.card != null && this.effectiveCard != null) ? (() => {
-      if (this.card != this.effectiveCard) {
-        this.effectiveCard._history = this.card._history;
-      } 
+      if (this.card != this.effectiveCard) this.effectiveCard._history = this.card._history;
       return this.effectiveCard.toJSON()
     })() : "TBD";
 
     return {
+      "fqn": this.identifier ? this.identifier.fqn : this._text,
+      // "namespace": this.identifier.name,
+      // "name": this.identifier.name,
+      "valueType": this.constructor.name,
       "card": this.effectiveCard != null ? card : "TBD",
-      "constraints": constraints,
-      "type": this.constructor.name,
-      "inheritance": {
+      "constraints": Object.keys(constraints).length > 0 ? constraints : undefined,
+      "inheritance": (this._inheritance) ? {
         "status": this._inheritance,
         "from": this._inheritedFrom.identifier != null ? this._inheritedFrom.identifier.fqn : undefined,
-      }
-    }
+      } : undefined
+    };
   }
 }
 
 class IdentifiableValue extends Value {
-//pragma region collapse
+ 
   constructor(identifier) {
     super();
     this._identifier = identifier; // Identifier
@@ -1337,14 +1336,14 @@ class IdentifiableValue extends Value {
   toString() {
     return this.identifier.name;
   }
-//pragma endregion collapse
-  toJSON() {
-    return  { [this._identifier.fqn]: super.toJSON() };  
-  }  
+ 
+  // toJSON() {
+  //   return  { [this._identifier.fqn]: super.toJSON() };  
+  // }  
 }
 
 class RefValue extends IdentifiableValue {
-//pragma region collapse
+ 
   constructor(identifier) {
     super(identifier);
   }
@@ -1358,15 +1357,11 @@ class RefValue extends IdentifiableValue {
   toString() {
     return `ref(${this.identifier.name})`
   }
-//pragma endregion collapse
-  toJSON() {
-    return {[this._identifier.fqn]: super.toJSON()};  
-  }
 }
 
 class ChoiceValue extends Value {
 
-//pragma region collapse
+ 
   constructor() {
     super();
     this._options = []; // Value[]
@@ -1438,12 +1433,16 @@ class ChoiceValue extends Value {
     str += ')';
     return str;
   }
-//pragma endregion collapse
+ 
   toJSON() {
     return {
-      "type": this.constructor.name, 
-      "constraints": this._constraints.map(c => c),
-      "options" : this._options.map(v => v.toJSON())
+      "valueType": this.constructor.name, 
+      // "constraints": this._constraints.map(c => c),
+      "options": this._options.map(v => {
+        let option = Object.assign({}, v.toJSON());
+        delete option["card"]
+        return option
+      })
     };
   }
 }
@@ -1453,7 +1452,7 @@ class ChoiceValue extends Value {
 // constraint is applied without knowing the full context of the current data element (in the case of the importer).
 // If a data element is fully resolved, it should never contain an IncompleteValue.
 class IncompleteValue extends IdentifiableValue {
-//pragma region collapse
+ 
   constructor(identifier) {
     super(identifier);
   }
@@ -1467,14 +1466,10 @@ class IncompleteValue extends IdentifiableValue {
   toString() {
     return `IncompleteValue<${this.identifier.fqn}>`;
   }
-//pragma endregion collapse
-  toJSON() {
-    return {[this._identifier.fqn]: super.toJSON()};  
-  }
 }
 
 class TBD extends Value{
-//pragma region collapse
+ 
   constructor(text) {
     super();
     this._text = text;
@@ -1507,16 +1502,16 @@ class TBD extends Value{
   toString() {
     return this._text ? `TBD(${this._text})` : 'TBD';
   }
-//pragma endregion collapse
-  toJSON() {
-    var val = {}
-    val[this.toString()]=super.toJSON();
-    return val;
-  }
+ 
+  // toJSON() {
+  //   var val = {}
+  //   val[this.toString()]=super.toJSON();
+  //   return val;
+  // }
 }
 
 class ValueSet  {
-//pragma region collapse
+ 
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1644,20 +1639,24 @@ class ValueSet  {
   }
 
   toJSON() {
+    var rule = (ruleFilter) => ruleFilter._rules.map(r => r.toJSON());
     var out = {
-      "name": this._identifier._name,
-      "namespace": this._identifier.namespace,
+      "name":        this._identifier._name,
+      "namespace":   this._identifier.namespace,
+      "fqn":         this._identifier.fqn,      
       "description": this._description,
-      "concepts": this.concepts.map(c => c.toJSON()),
-      "url": this._url,
-      "values": this.rulesFilter.includesCode._rules.map(r => r.toJSON()),
-      "relationships": {
-        "includesDescendants":    this.rulesFilter.includesDescendents._rules.map(r => r.toJSON()),
-        "includesFromCode":       this.rulesFilter.includesFromCode._rules.map(r => r.toJSON()),
-        "includesFromCodeSystem": this.rulesFilter.includesFromCodeSystem._rules.map(r => r.toJSON()),
-        "excludesDescendants":    this.rulesFilter.excludesDescendents._rules.map(r => r.toJSON()),
+      "concepts":    this.concepts.map(c => c.toJSON()),
+      "url":         this._url,
+      "values":      this.rulesFilter.includesCode._rules.map(r => r.toJSON()),
+      "rules": {
+        "includesDescendants":    rule(this.rulesFilter.includesDescendents),
+        "includesFromCode":       rule(this.rulesFilter.includesFromCode),
+        "includesFromCodeSystem": rule(this.rulesFilter.includesFromCodeSystem),
+        "excludesDescendants":    rule(this.rulesFilter.excludesDescendents),
       }
     }
+
+    clearEmptyFields(out, true);    
 
     return out;
   }
@@ -1665,7 +1664,7 @@ class ValueSet  {
 
 // Note -- this should be consider abstract.  Do not instantiate!
 class ValueSetCodeRule {
-//pragma region collapse
+ 
   constructor(code) {
     this._code = code;
   }
@@ -1675,7 +1674,7 @@ class ValueSetCodeRule {
 
 // ValueSetIncludesCodeRule indicates that the given code should be directly included in the value set
 class ValueSetIncludesCodeRule extends ValueSetCodeRule {
-//pragma region collapse
+ 
   constructor(code) {
     super(code);
   }
@@ -1688,14 +1687,14 @@ class ValueSetIncludesCodeRule extends ValueSetCodeRule {
     return {
       "system": this._code.system,
       "code": this._code.code,
-      "display": this._code.display
+      "description": this._code.display
     }
   }
 }
 
 // ValueSetIncludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be included in the value set
 class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
-//pragma region collapse
+ 
   constructor(code) {
     super(code);
   }
@@ -1708,14 +1707,14 @@ class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
     return {
       "system": this._code.system,
       "code": this._code.code,
-      "display": this._code.display
+      "description": this._code.display
     }
   }
 }
 
 // ValueSetExcludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be excluded from the value set
 class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
-//pragma region collapse
+ 
   constructor(code) {
     super(code);
   }
@@ -1728,14 +1727,14 @@ class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
     return {
       "system": this._code.system,
       "code": this._code.code,
-      "display": this._code.display
+      "description": this._code.display
     }
   }
 }
 
 // ValueSetIncludesFromCodeSystemRule indicates that all codes in the given code system should be included in the value set
 class ValueSetIncludesFromCodeSystemRule {
-//pragma region collapse
+ 
   constructor(system) {
     this._system = system;
   }
@@ -1753,7 +1752,7 @@ class ValueSetIncludesFromCodeSystemRule {
 
 // ValueSetIncludesFromCodeRule indicates that codes referenced by the given code should be included in the value set
 class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
-//pragma region collapse
+ 
   constructor(code) {
     super(code);
   }
@@ -1766,13 +1765,13 @@ class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
     return {
       "system":   this._code.system,
       "code":     this._code.code,
-      "display":  this._code.display
+      "description":  this._code.display
     }
   }
 }
 
 class ValueSetRulesFilter {
-//pragma region collapse
+ 
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -1802,7 +1801,7 @@ class ValueSetRulesFilter {
 }
 
 class CodeSystem  {
-//pragma region collapse
+ 
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1866,7 +1865,7 @@ class CodeSystem  {
 
 
 class ElementMapping {
-//pragma region collapse
+ 
   constructor(identifier, targetSpec, targetItem) {
     this._identifier = identifier;
     this._targetSpec = targetSpec;
@@ -1970,21 +1969,23 @@ class ElementMapping {
       "name": this.identifier.name,
       "namespace": this.identifier.namespace,
       "fqn": this.identifier.fqn,
-      "target_spec": this.targetSpec,
-      "target_item": this.targetItem,
+      "targetSpec": this.targetSpec,
+      "targetItem": this.targetItem,
       "mappings": {
-        "fieldMapping": this.rulesFilter.field._rules.map(m => m.toJSON()),
+        "fieldMapping": this.rulesFilter.field._rules.map(m => m.toJSON()), //TODO make hierarchial
         "cardMapping": this.rulesFilter.cardinality._rules.map(m => m.toJSON()),
         "fixedValue": this.rulesFilter.fixedValue._rules.map(m => m.toJSON())
       }
     }
 
+    clearEmptyFields(out, true)
+    
     return out;
   }
 }
 
 class FieldMappingRule {
-//pragma region collapse
+ 
   constructor(sourcePath = [], target = '') {
     this._sourcePath = sourcePath; // array of identifiers
     this._target = target; // string
@@ -2014,7 +2015,7 @@ class FieldMappingRule {
 }
 
 class CardinalityMappingRule {
-//pragma region collapse
+ 
   constructor(target = '', cardinality) {
     this._target = target;   // string
     this._cardinality = cardinality; // Cardinality
@@ -2040,7 +2041,7 @@ class CardinalityMappingRule {
 }
 
 class FixedValueMappingRule {
-//pragma region collapse
+ 
   constructor(target = '', value='') {
     this._target = target;   // string
     this._value = value; // string
@@ -2066,7 +2067,7 @@ class FixedValueMappingRule {
 }
 
 class MappingRulesFilter {
-//pragma region collapse
+ 
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -2111,7 +2112,7 @@ class MappingRulesFilter {
 }
 
 class Version {
-//pragma region collapse
+ 
   constructor(major, minor = 0, patch = 0) {
     this._major = major;
     this._minor = minor;

--- a/lib/models.js
+++ b/lib/models.js
@@ -515,7 +515,7 @@ class DataElement {
       "isAbstract":   this.isAbstract,
       "description":  this.description,
       "concepts":     this.concepts.map(c => c.toJSON()),
-      "hierarchy":    this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
+      "hierarchy":    this._hierarchy.map(h => h.identifier.fqn), //full hierarchy
       "basedOn":      this.basedOn.map(b => b.fqn || b.toString()),
       "value":        this.value != null ? this.value.toJSON() : undefined,
       "fields":       this._fields.map(f => f.toJSON()),
@@ -620,7 +620,7 @@ class Cardinality {
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
-    this._history = []; // dictionary[] (min,max,source)
+    //additional properties: source (DataElement), history (Cardinality[])
   }
 
   get min() { return this._min; }
@@ -632,10 +632,6 @@ class Cardinality {
   }
   get max() { return this._max; }
   set max(max) { this._max = max; }
-  // withMin is a convenience function for chaining
-
-  get history() { return this._history; }
-  set history(history) { this._history = history; }
 
   withMax(max) {
     this.max = max;
@@ -655,6 +651,36 @@ class Cardinality {
   }
   get isList() {
     return this._max > 1 || this.isMaxUnbounded;
+  }
+
+  get source() { return this._source; }
+  set source(source) { this._source = source; }
+
+  // withSource is a convenience function for chaining
+  withSource(source) {
+    this.source = source;
+    return this;
+  }
+  get history() { return this._history; }
+  set history(history) { this._history = history; }
+  // withHistory is a convenience function for chaining  
+  withHistory(card) {
+    this.addHistory(card);
+    return this;
+  }
+
+  // addHistory is a convenience function for chaining
+  addHistory(card) {
+    if (!this.history) this.history = [];
+    this.history.push(card);
+    return this;
+  }
+
+  // withHistories is a convenience function for chaining
+  withHistories(histories) {
+    if (!this.history) this.history = [];
+    this.history.push(...histories);
+    return this;
   }
 
   fitsWithinCardinalityOf(other) {
@@ -683,7 +709,7 @@ class Cardinality {
 
     if (this._history && this._history.length > 0) {
       out["history"] = this._history.map(h => ({
-        "source": h["source"],
+        "source": h._source.fqn,
         "min": h._min,
         "max": h._max
       }))
@@ -698,7 +724,6 @@ class Constraint {
  
   constructor(path = []) {
     this._path = path;
-    this._lastModifiedBy = undefined;
   }
 
   get path() { return this._path; }
@@ -714,7 +739,11 @@ class Constraint {
 
   get lastModifiedBy() { return this._lastModifiedBy; }
   set lastModifiedBy(lastModifiedBy) { this._lastModifiedBy = lastModifiedBy; }
-
+  // withLastModified is a convenience function for chaining
+  withLastModifiedBy(lastModifiedBy) {
+    this.lastModifiedBy = lastModifiedBy;
+    return this;
+  }
 
   _clonePropertiesTo(clone) {
     for (const p of this._path) {
@@ -744,7 +773,7 @@ class Constraint {
 
   toJSON() {
     return {
-      "lastModifiedBy": (this.lastModifiedBy) ? (this.lastModifiedBy.identifier ? this.lastModifiedBy.identifier.fqn : this.lastModifiedBy.text) : undefined,
+      "lastModifiedBy": (this.lastModifiedBy) ? this.lastModifiedBy.fqn : undefined,
     }
   }
 }
@@ -1071,8 +1100,6 @@ class Value {
  
   constructor() {
     this._constraints = [];
-    this._inheritance = undefined;
-    this._inheritedFrom = undefined;
   }
 
   // card is the Cardinality for the value.
@@ -1275,7 +1302,7 @@ class Value {
       "constraints": Object.keys(constraints).length > 0 ? constraints : undefined,
       "inheritance": (this._inheritance) ? {
         "status": this._inheritance,
-        "from": this._inheritedFrom.identifier.fqn,
+        "from": this._inheritedFrom.fqn,
       } : undefined
     };
   }

--- a/lib/models.js
+++ b/lib/models.js
@@ -620,7 +620,7 @@ class Cardinality {
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
-    //additional properties: source (DataElement), history (Cardinality[])
+    //additional properties: source (Identifier), history (Cardinality[])
   }
 
   get min() { return this._min; }
@@ -709,7 +709,7 @@ class Cardinality {
 
     if (this._history && this._history.length > 0) {
       out["history"] = this._history.map(h => ({
-        "source": h._source.fqn,
+        "source": (h._source && h._source.fqn) ? h._source.fqn : undefined,
         "min": h._min,
         "max": h._max
       }))

--- a/lib/models.js
+++ b/lib/models.js
@@ -1157,6 +1157,12 @@ class Value {
   set inheritedFrom(inheritedFrom) {
     this._inheritedFrom = inheritedFrom;
   }
+
+  withInheritedFrom(parent) {
+    this.inheritedFrom = parent;
+    return this;
+  }
+
   // withInheritance is a convenience function for chaining
   withInheritance(inheritance) {
     this.inheritance = inheritance;

--- a/lib/models.js
+++ b/lib/models.js
@@ -1088,7 +1088,7 @@ class Value {
   constructor() {
     this._constraints = [];
     this._inheritance = undefined;
-    this._inheritedFrom = {}
+    this._inheritedFrom = undefined;
   }
 
   // card is the Cardinality for the value.
@@ -1271,15 +1271,12 @@ class Value {
     })() : "TBD";
 
     return {
-      "fqn": this.identifier ? this.identifier.fqn : this._text,
-      // "namespace": this.identifier.name,
-      // "name": this.identifier.name,
       "valueType": this.constructor.name,
       "card": this.effectiveCard != null ? card : "TBD",
       "constraints": Object.keys(constraints).length > 0 ? constraints : undefined,
       "inheritance": (this._inheritance) ? {
         "status": this._inheritance,
-        "from": this._inheritedFrom.identifier != null ? this._inheritedFrom.identifier.fqn : undefined,
+        "from": this._inheritedFrom.identifier.fqn,
       } : undefined
     };
   }
@@ -1337,9 +1334,16 @@ class IdentifiableValue extends Value {
     return this.identifier.name;
   }
  
-  // toJSON() {
-  //   return  { [this._identifier.fqn]: super.toJSON() };  
-  // }  
+  toJSON() {
+    return Object.assign(
+      {
+        "fqn": this.identifier.fqn,
+        // "namespace": this.identifier.name,
+        // "name": this.identifier.name,  
+      },
+      super.toJSON()
+    );  
+  }  
 }
 
 class RefValue extends IdentifiableValue {
@@ -1435,15 +1439,13 @@ class ChoiceValue extends Value {
   }
  
   toJSON() {
-    return {
-      "valueType": this.constructor.name, 
-      // "constraints": this._constraints.map(c => c),
+    return Object.assign(super.toJSON(), {
       "options": this._options.map(v => {
         let option = Object.assign({}, v.toJSON());
         delete option["card"]
         return option
       })
-    };
+    });
   }
 }
 
@@ -1503,11 +1505,14 @@ class TBD extends Value{
     return this._text ? `TBD(${this._text})` : 'TBD';
   }
  
-  // toJSON() {
-  //   var val = {}
-  //   val[this.toString()]=super.toJSON();
-  //   return val;
-  // }
+  toJSON() {
+    return Object.assign(
+      {
+        "fqn" : this.text
+      },
+      super.toJSON()
+    );
+  }
 }
 
 class ValueSet  {

--- a/lib/models.js
+++ b/lib/models.js
@@ -37,11 +37,12 @@ function sanityCheckModules(modelInfoMap) {
 }
 
 class Specifications {
+//pragma region collapse
   constructor() {
     this._namespaces = new NamespaceSpecifications();
     this._dataElements = new DataElementSpecifications();
     this._valueSets = new ValueSetSpecifications();
-    this._codeSystems = new CodeSystemSpecifications();
+    this._codeSystems = new CodeSystemSpecifications();1
     this._maps = new MapSpecifications();
   }
 
@@ -53,6 +54,7 @@ class Specifications {
 }
 
 class NamespaceSpecifications {
+//pragma region collapse
   constructor() {
     this._nsMap = new Map();
   }
@@ -69,6 +71,7 @@ class NamespaceSpecifications {
 }
 
 class DataElementSpecifications {
+//pragma region collapse
   constructor() {
     this._nsMap = new Map();
     this._grammarVersions = new Map();
@@ -123,9 +126,16 @@ class DataElementSpecifications {
   findByIdentifier(identifier) {
     return this.find(identifier.namespace, identifier.name);
   }
+
+//pragma endregion collapse
+
+  // toJSON() {
+  
+  // }
 }
 
 class ValueSetSpecifications {
+//pragma region collapse
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -175,6 +185,7 @@ class ValueSetSpecifications {
 }
 
 class CodeSystemSpecifications {
+//pragma region collapse
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -224,6 +235,7 @@ class CodeSystemSpecifications {
 }
 
 class MapSpecifications {
+//pragma region collapse
   constructor() {
     this._targetMap = new Map();
     this._grammarVersions = new Map();
@@ -280,6 +292,7 @@ class MapSpecifications {
 }
 
 class TargetMapSpecifications {
+//pragma region collapse
   constructor(target) {
     this._target = target;
     this._nsMap = new Map();
@@ -328,6 +341,7 @@ class TargetMapSpecifications {
 }
 
 class Namespace {
+//pragma region collapse
   constructor(namespace, description) {
     this._namespace = namespace; // string
     this._description = description; // string
@@ -349,9 +363,20 @@ class Namespace {
   clone() {
     return new Namespace(this._namespace, this._description);
   }
+
+//pragma endregion
+
+  toJSON() {
+    return {
+      "name": this.namespace,
+      "description": this.description,
+      "external_dependencies" : []
+    }
+  }  
 }
 
 class DataElement {
+//pragma region foo
   constructor(identifier, isEntry=false, isAbstract=false) {
     this._identifier = identifier; // Identifier
     this._isEntry = isEntry; // boolean
@@ -361,7 +386,6 @@ class DataElement {
     this._fields = [];       // Value[] (and its subclasses) -- excluding primitive values
     // also contains _value, _description, and _grammarVersion
   }
-
   // identifier is the unique Identifier (namespace+name) for the DataElement
   get identifier() { return this._identifier; }
 
@@ -376,7 +400,6 @@ class DataElement {
   set isAbstract(isAbstract) {
     this._isAbstract = isAbstract;
   }
-
   // basedOn is an array of identifiers that the data element is based on.  This means that it takes on the value
   // and fields of any data element it is based on, and can potentially override/constrain it.
   get basedOn() { return this._basedOn; }
@@ -388,7 +411,7 @@ class DataElement {
     this.addBasedOn(basedOn);
     return this;
   }
-
+  
   // concepts are an array of Concept
   get concepts() { return this._concepts; }
   set concepts(concepts) {
@@ -402,7 +425,7 @@ class DataElement {
     this.addConcept(concept);
     return this;
   }
-
+  
   // a description is a string
   get description() { return this._description; }
   set description(description) {
@@ -413,7 +436,7 @@ class DataElement {
     this.description = description;
     return this;
   }
-
+  
   // Data elements should have a value, or a set of fields, or both a value and set of fields.
   get value() { return this._value; }
   set value(value) {
@@ -424,7 +447,7 @@ class DataElement {
     this.value = value;
     return this;
   }
-
+  
   // Data elements should have a value, or a set of fields, or both a value and set of fields.
   // Fields cannot be primitive values.
   get fields() { return this._fields; }
@@ -439,7 +462,7 @@ class DataElement {
     this.addField(field);
     return this;
   }
-
+  
   // the Version of the grammar used to define this element
   get grammarVersion() { return this._grammarVersion; }
   set grammarVersion(grammarVersion) {
@@ -450,7 +473,7 @@ class DataElement {
     this.grammarVersion = grammarVersion;
     return this;
   }
-
+  
   clone() {
     const clone = new DataElement(this._identifier.clone(), this._isEntry, this._isAbstract);
     if (this._description) {
@@ -473,10 +496,30 @@ class DataElement {
     }
     return clone;
   }
+//pragma endregion foo
+
+  toJSON() {
+    var outputJSON = {
+      "name":       this.identifier.name,
+      "namespace":  this.identifier.namespace,
+      "isEntry":    this.isEntry,
+      "isAbstract": this.isAbstract,
+      "concepts":   this.concepts.map(c => c.toJSON()),
+      "basedOn":    this.basedOn.map(b => b.fqn),
+      "fields":     {},
+      "value": {}
+    };    
+  outputJSON.fields = this._fields.reduce((out,f) => Object.assign(out, f.toJSON()), {})
+  outputJSON.value = this.value != null ? this.value.toJSON() : "undefined";
+
+    return outputJSON;
+  }
 }
 
 class Concept {
-  constructor(system, code, display) {
+
+//pragma region collapse
+constructor(system, code, display) {
     this._system = system;
     this._code = code;
     this._display = display;
@@ -499,6 +542,15 @@ class Concept {
     return new Concept(this._system, this._code, this._display);
   }
 
+  toJSON() {
+    return {
+      "system": this.system,
+      "code": this.code,
+      "display": this.display
+    }
+  }
+
+
   /**
    * Check concepts for equality. Note that this ignores the display property.
    *
@@ -508,9 +560,12 @@ class Concept {
   equals(other) {
     return (other instanceof Concept) && this._system == other.system && this._code == other.code;
   }
+
+
 }
 
 class Identifier {
+//pragma region collapse
   constructor(namespace, name) {
     this._namespace = namespace; // string
     this._name = name; // string
@@ -545,12 +600,14 @@ class Identifier {
 }
 
 class PrimitiveIdentifier extends Identifier {
+//pragma region collapse
   constructor(name) {
     super(PRIMITIVE_NS, name);
   }
 }
 
 class Cardinality {
+//pragma region collapse
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
@@ -603,9 +660,17 @@ class Cardinality {
   toString() {
     return `${this.min}..${this.isMaxUnbounded ? '*' : this.max}`;
   }
+
+  toJSON() {
+    return {
+      "min": this._min,
+      "max": (typeof this._max === 'undefined' || this._max == null) ? "*" : this._max
+    }
+  }
 }
 
 class Constraint {
+//pragma region collapse
   constructor(path = []) {
     this._path = path;
   }
@@ -646,10 +711,15 @@ class Constraint {
     }
     return true;
   }
+
+  toJSON() {
+
+  }
 }
 
 // ValueSetConstraint only makes sense on a code or Coding type value
 class ValueSetConstraint extends Constraint {
+//pragma region collapse
   constructor(valueSet, path, bindingStrength=REQUIRED) {
     super(path);
     this._valueSet = valueSet;
@@ -686,6 +756,7 @@ class ValueSetConstraint extends Constraint {
 
 // CodeConstraint only makes sense on a code or Coding type value
 class CodeConstraint extends Constraint {
+//pragma region collapse
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -708,6 +779,7 @@ class CodeConstraint extends Constraint {
 
 // IncludesCodeConstraint only makes sense on an array of code or Coding
 class IncludesCodeConstraint extends Constraint {
+//pragma region collapse
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -730,6 +802,7 @@ class IncludesCodeConstraint extends Constraint {
 
 // BooleanConstraint only makes sense on a boolean
 class BooleanConstraint extends Constraint {
+//pragma region collapse
   constructor(value, path) {
     super(path);
     this._value = value;
@@ -751,6 +824,7 @@ class BooleanConstraint extends Constraint {
 }
 
 class TypeConstraint extends Constraint {
+//pragma region collapse
   constructor(isA, path, onValue = false) {
     super(path);
     this._isA = isA;
@@ -785,6 +859,7 @@ class TypeConstraint extends Constraint {
 }
 
 class IncludesTypeConstraint extends Constraint {
+//pragma region collapse
   constructor(isA, card, path, isOnValue=false) {
     super(path);
     this._isA = isA;
@@ -815,6 +890,7 @@ class IncludesTypeConstraint extends Constraint {
 }
 
 class CardConstraint extends Constraint {
+//pragma region collapse
   constructor(card, path) {
     super(path);
     this._card = card;
@@ -836,6 +912,7 @@ class CardConstraint extends Constraint {
 }
 
 class ConstraintsFilter {
+//pragma region collapse
   constructor(constraints = []) {
     this._constraints = constraints;
   }
@@ -905,6 +982,7 @@ class ConstraintsFilter {
 }
 
 class Value {
+//pragma region collapse
   constructor() {
     this._constraints = [];
   }
@@ -1045,9 +1123,26 @@ class Value {
 
     return true;
   }
+//pragma endregion collapse
+  toJSON() {
+    return {
+      "card": this._card != null ? this._card.toJSON() : "TBD",
+      "constraints": this._constraints.map(c => c),
+      "type": this.constructor.name,
+    }
+  }
+//pragma endregion collapse
+  toJSON() {
+    return {
+      "card": this._card != null ? this._card.toJSON() : "TBD",
+      "constraints": this._constraints.map(c => c),
+      "type": this.constructor.name,
+    }
+  }
 }
 
 class IdentifiableValue extends Value {
+//pragma region collapse
   constructor(identifier) {
     super();
     this._identifier = identifier; // Identifier
@@ -1097,9 +1192,16 @@ class IdentifiableValue extends Value {
   toString() {
     return this.identifier.name;
   }
+//pragma endregion collapse
+  toJSON() {
+    var val = {};
+    val[this._identifier.fqn] = super.toJSON();
+    return val;  
+  }  
 }
 
 class RefValue extends IdentifiableValue {
+//pragma region collapse
   constructor(identifier) {
     super(identifier);
   }
@@ -1113,9 +1215,17 @@ class RefValue extends IdentifiableValue {
   toString() {
     return `ref(${this.identifier.name})`
   }
+//pragma endregion collapse
+  toJSON() {
+    var val = {};
+    val[this._identifier.fqn] = super.toJSON();
+    return val;  
+  }
 }
 
 class ChoiceValue extends Value {
+
+//pragma region collapse
   constructor() {
     super();
     this._options = []; // Value[]
@@ -1187,6 +1297,15 @@ class ChoiceValue extends Value {
     str += ')';
     return str;
   }
+//pragma endregion collapse
+  toJSON() {
+    var val = {
+      "type": this.constructor.name, 
+      "constraints": this._constraints.map(c => c),
+      "options" : this._options.map(v => v.toJSON())
+    };
+    return val;  
+  }
 }
 
 // IncompleteValue provides a place to put constraints when the full definition of the thing being constrained is
@@ -1194,6 +1313,7 @@ class ChoiceValue extends Value {
 // constraint is applied without knowing the full context of the current data element (in the case of the importer).
 // If a data element is fully resolved, it should never contain an IncompleteValue.
 class IncompleteValue extends IdentifiableValue {
+//pragma region collapse
   constructor(identifier) {
     super(identifier);
   }
@@ -1207,9 +1327,16 @@ class IncompleteValue extends IdentifiableValue {
   toString() {
     return `IncompleteValue<${this.identifier.fqn}>`;
   }
+//pragma endregion collapse
+  toJSON() {
+    var val = {};
+    val[this._identifier.fqn] = super.toJSON();
+    return val;  
+  }
 }
 
 class TBD extends Value{
+//pragma region collapse
   constructor(text) {
     super();
     this._text = text;
@@ -1242,9 +1369,16 @@ class TBD extends Value{
   toString() {
     return this._text ? `TBD(${this._text})` : 'TBD';
   }
+//pragma endregion collapse
+  toJSON() {
+    var val = {}
+    val[this.toString()]=super.toJSON();
+    return val;
+  }
 }
 
 class ValueSet  {
+//pragma region collapse
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1374,6 +1508,7 @@ class ValueSet  {
 
 // Note -- this should be consider abstract.  Do not instantiate!
 class ValueSetCodeRule {
+//pragma region collapse
   constructor(code) {
     this._code = code;
   }
@@ -1383,6 +1518,7 @@ class ValueSetCodeRule {
 
 // ValueSetIncludesCodeRule indicates that the given code should be directly included in the value set
 class ValueSetIncludesCodeRule extends ValueSetCodeRule {
+//pragma region collapse
   constructor(code) {
     super(code);
   }
@@ -1394,6 +1530,7 @@ class ValueSetIncludesCodeRule extends ValueSetCodeRule {
 
 // ValueSetIncludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be included in the value set
 class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
+//pragma region collapse
   constructor(code) {
     super(code);
   }
@@ -1405,6 +1542,7 @@ class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
 
 // ValueSetExcludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be excluded from the value set
 class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
+//pragma region collapse
   constructor(code) {
     super(code);
   }
@@ -1416,6 +1554,7 @@ class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
 
 // ValueSetIncludesFromCodeSystemRule indicates that all codes in the given code system should be included in the value set
 class ValueSetIncludesFromCodeSystemRule {
+//pragma region collapse
   constructor(system) {
     this._system = system;
   }
@@ -1429,6 +1568,7 @@ class ValueSetIncludesFromCodeSystemRule {
 
 // ValueSetIncludesFromCodeRule indicates that codes referenced by the given code should be included in the value set
 class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
+//pragma region collapse
   constructor(code) {
     super(code);
   }
@@ -1439,6 +1579,7 @@ class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
 }
 
 class ValueSetRulesFilter {
+//pragma region collapse
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -1468,6 +1609,7 @@ class ValueSetRulesFilter {
 }
 
 class CodeSystem  {
+//pragma region collapse
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1514,6 +1656,7 @@ class CodeSystem  {
   }
 
   clone() {
+//TODO: wed
     const clone = new CodeSystem(this._identifier, this._url);
     if (this._description) {
       clone._description = this._description;
@@ -1530,6 +1673,7 @@ class CodeSystem  {
 
 
 class ElementMapping {
+//pragma region collapse
   constructor(identifier, targetSpec, targetItem) {
     this._identifier = identifier;
     this._targetSpec = targetSpec;
@@ -1615,6 +1759,7 @@ class ElementMapping {
 }
 
 class FieldMappingRule {
+//pragma region collapse
   constructor(sourcePath = [], target = '') {
     this._sourcePath = sourcePath; // array of identifiers
     this._target = target; // string
@@ -1637,6 +1782,7 @@ class FieldMappingRule {
 }
 
 class CardinalityMappingRule {
+//pragma region collapse
   constructor(target = '', cardinality) {
     this._target = target;   // string
     this._cardinality = cardinality; // Cardinality
@@ -1655,6 +1801,7 @@ class CardinalityMappingRule {
 }
 
 class FixedValueMappingRule {
+//pragma region collapse
   constructor(target = '', value='') {
     this._target = target;   // string
     this._value = value; // string
@@ -1673,6 +1820,7 @@ class FixedValueMappingRule {
 }
 
 class MappingRulesFilter {
+//pragma region collapse
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -1717,6 +1865,7 @@ class MappingRulesFilter {
 }
 
 class Version {
+//pragma region collapse
   constructor(major, minor = 0, patch = 0) {
     this._major = major;
     this._minor = minor;

--- a/lib/models.js
+++ b/lib/models.js
@@ -384,6 +384,7 @@ class DataElement {
     this._basedOn = [];      // Identifier[]
     this._concepts = [];     // Concept[]
     this._fields = [];       // Value[] (and its subclasses) -- excluding primitive values
+    this._hierarchy = [];
     // also contains _value, _description, and _grammarVersion
   }
   // identifier is the unique Identifier (namespace+name) for the DataElement
@@ -473,7 +474,13 @@ class DataElement {
     this.grammarVersion = grammarVersion;
     return this;
   }
-  
+
+  get hierarchy() { return this._hierarchy; }
+  set hierarchy(hierarchy) {
+    this._hierarchy = hierarchy;
+  }
+
+
   clone() {
     const clone = new DataElement(this._identifier.clone(), this._isEntry, this._isAbstract);
     if (this._description) {
@@ -500,17 +507,19 @@ class DataElement {
 
   toJSON() {
     var outputJSON = {
-      "name":       this.identifier.name,
-      "namespace":  this.identifier.namespace,
-      "isEntry":    this.isEntry,
+      "name": this.identifier.name,
+      "namespace": this.identifier.namespace,
+      "isEntry": this.isEntry,
       "isAbstract": this.isAbstract,
-      "concepts":   this.concepts.map(c => c.toJSON()),
-      "basedOn":    this.basedOn.map(b => b.fqn),
-      "fields":     {},
-      "value": {}
-    };    
-  outputJSON.fields = this._fields.reduce((out,f) => Object.assign(out, f.toJSON()), {})
-  outputJSON.value = this.value != null ? this.value.toJSON() : "undefined";
+      "concepts": this.concepts.map(c => c.toJSON()),
+      "hierarchy": this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
+      "basedOn": this.basedOn.map(b => b.fqn),
+      "value": {},
+      "fields": {},
+    };
+
+    outputJSON.fields = this._fields.reduce((out, f) => Object.assign(out, f.toJSON()), {})
+    outputJSON.value = this.value != null ? this.value.toJSON() : "undefined";
 
     return outputJSON;
   }
@@ -611,6 +620,7 @@ class Cardinality {
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
+    this._history = [];
   }
 
   get min() { return this._min; }
@@ -662,10 +672,21 @@ class Cardinality {
   }
 
   toJSON() {
-    return {
+    var out = {
       "min": this._min,
-      "max": (typeof this._max === 'undefined' || this._max == null) ? "*" : this._max
+      "max": this._max
+    };
+
+    if (this._history.length > 0) {
+      out["history"] = this._history.map(h => ({
+        "source": h["source"],
+        "min": h._min,
+        "max": h._max
+      }))
     }
+
+    return out;
+
   }
 }
 
@@ -713,7 +734,14 @@ class Constraint {
   }
 
   toJSON() {
-
+    return {
+      // "path": this._path.map(p => ({
+      //   "namespace": p._namespace,
+      //   "name": p._name,
+      //   "fqn": p.fqn
+      // })), 
+      // "type": this.constructor.name      
+    }
   }
 }
 
@@ -752,6 +780,13 @@ class ValueSetConstraint extends Constraint {
         this._valueSet == other.valueSet &&
         this._pathsAreEqual(other);
   }
+
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["value_set"] = this._valueSet;
+    constraint["binding_strength"] = this._bindingStrength
+    return constraint;  
+  }
 }
 
 // CodeConstraint only makes sense on a code or Coding type value
@@ -774,6 +809,17 @@ class CodeConstraint extends Constraint {
     return (other instanceof CodeConstraint) &&
         this._code.equals(other.code) &&
         this._pathsAreEqual(other);
+  }
+
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["type"]  = "code";
+    constraint["value"] = {
+      "system": this._code.system,
+      "code": this._code.code
+    }
+    delete constraint["path"];
+    return constraint;
   }
 }
 
@@ -798,6 +844,15 @@ class IncludesCodeConstraint extends Constraint {
         this._code.equals(other.code) &&
         this._pathsAreEqual(other);
   }
+  
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["code"] = {
+      "system": this._code.system,
+      "code": this._code.code
+    }
+    return constraint;
+  }
 }
 
 // BooleanConstraint only makes sense on a boolean
@@ -820,6 +875,14 @@ class BooleanConstraint extends Constraint {
     return (other instanceof BooleanConstraint) &&
         this._value == other.value &&
         this._pathsAreEqual(other);
+  }
+
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["value"] = this._value
+    constraint["type"]  = "boolean";
+    delete constraint["path"];
+    return constraint;
   }
 }
 
@@ -856,6 +919,16 @@ class TypeConstraint extends Constraint {
         this._isA.equals(other.isA) &&
         this._pathsAreEqual(other);
   }
+
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["isA"] = {
+      "namespace": this._isA.namespace,
+      "name": this._isA.name
+    }
+    constraint["onValue"] = this._onValue;
+    return constraint;
+  }
 }
 
 class IncludesTypeConstraint extends Constraint {
@@ -887,6 +960,17 @@ class IncludesTypeConstraint extends Constraint {
         this._card.equals(other.card) &&
         this._pathsAreEqual(other);
   }
+
+  toJSON() {
+    var constraint = super.toJSON();
+    constraint["isA"] = {
+      "namespace": this._isA.namespace,
+      "name": this._isA.name
+    }
+    constraint["card"] = this._card.toJSON();
+    constraint["isOnValue"] = this._isOnValue;
+    return constraint;
+  }
 }
 
 class CardConstraint extends Constraint {
@@ -908,6 +992,12 @@ class CardConstraint extends Constraint {
     return (other instanceof CardConstraint) &&
         this._card.equals(other.card) &&
         this._pathsAreEqual(other);
+  }
+
+  toJSON() {
+    var constraint = Object.assign(super.toJSON(), this._card.toJSON());
+    delete constraint["path"];    
+    return constraint;
   }
 }
 
@@ -985,6 +1075,8 @@ class Value {
 //pragma region collapse
   constructor() {
     this._constraints = [];
+    this._inheritance = undefined;
+    this._inheritedFrom = {}
   }
 
   // card is the Cardinality for the value.
@@ -1058,6 +1150,11 @@ class Value {
   set inheritance(inheritance) {
     this._inheritance = inheritance;
   }
+
+  get inheritedFrom() { return this._inheritedFrom; }
+  set inheritedFrom(inheritedFrom) {
+    this._inheritedFrom = inheritedFrom;
+  }
   // withInheritance is a convenience function for chaining
   withInheritance(inheritance) {
     this.inheritance = inheritance;
@@ -1125,10 +1222,64 @@ class Value {
   }
 //pragma endregion collapse
   toJSON() {
+    
+    let constraints = this._constraints.reduce((out, c, i, e) => {
+      let key = c.constructor.name.replace(/constraint/i, '').replace(/^[a-zA-Z]/, (s) => s.toLowerCase());
+      let cst = c.toJSON(); 
+
+      var iterAdder = (constraint, outputDict, skipCard=false) => {
+        let arrConstraints  = ['includesType', 'includesCode'];
+        let dicConstraints  = ['type', 'valueSet', 'card'];
+        let valConstraints  = ['boolean', 'code'];
+        
+        (skipCard) ? dicConstraints.pop() : null;
+  
+        (arrConstraints.includes(key))  ? (outputDict[key] == null ? outputDict[key] == [] : true) && outputDict[key].push(cst)      :
+        (dicConstraints.includes(key))  ? outputDict[key] = cst          :
+        (valConstraints.includes(key))  ? outputDict['fixedValue'] = cst : null;  
+      }
+
+      if (c.path.length == 0) {
+        iterAdder(c, out, true)
+      } else if (c.path.length > 0) {
+        var currentSubField = out;
+        c.path.forEach((subC) => {
+          if (currentSubField['subpaths']           == null)  { currentSubField['subpaths'] = {} }
+          if (currentSubField['subpaths'][subC.fqn] == null)  { currentSubField['subpaths'][subC.fqn] = {} }
+          currentSubField = currentSubField['subpaths'][subC.fqn];
+          
+          iterAdder(subC, currentSubField)
+        })
+      }
+      
+      return out;
+    }, {
+      // "type":         {},
+      // "valueSet":     {},
+      // "fixedValue":   {},
+      // "includesType": [],
+      // "includesCode": [],
+      // "subpaths":     []
+      }
+    );
+
+    // Object.keys(constraints).forEach((key) => (constraints[key].length == 0 || !Object.keys(constraints[key]).length) && delete constraints[key]); //optionally: clear empty constraints
+
+    let card = (this.card != null && this.effectiveCard != null) ? (() => {
+      if (this.card != this.effectiveCard) {
+        this.effectiveCard._history = this.card._history;
+      } 
+      return this.effectiveCard.toJSON()
+    })() : "TBD";
+    
     return {
-      "card": this._card != null ? this._card.toJSON() : "TBD",
-      "constraints": this._constraints.map(c => c),
+      "card": this.effectiveCard != null ? card : "TBD",
+      "constraints": constraints,
       "type": this.constructor.name,
+      "inheritance": {
+        "status": this._inheritance,
+        "from": this._inheritedFrom.identifier != null ? this._inheritedFrom.identifier.fqn : undefined,
+      }
     }
   }
 //pragma endregion collapse
@@ -1194,9 +1345,7 @@ class IdentifiableValue extends Value {
   }
 //pragma endregion collapse
   toJSON() {
-    var val = {};
-    val[this._identifier.fqn] = super.toJSON();
-    return val;  
+    return  { [this._identifier.fqn]: super.toJSON() };  
   }  
 }
 
@@ -1217,9 +1366,7 @@ class RefValue extends IdentifiableValue {
   }
 //pragma endregion collapse
   toJSON() {
-    var val = {};
-    val[this._identifier.fqn] = super.toJSON();
-    return val;  
+    return {[this._identifier.fqn]: super.toJSON()};  
   }
 }
 
@@ -1299,12 +1446,11 @@ class ChoiceValue extends Value {
   }
 //pragma endregion collapse
   toJSON() {
-    var val = {
+    return {
       "type": this.constructor.name, 
       "constraints": this._constraints.map(c => c),
       "options" : this._options.map(v => v.toJSON())
     };
-    return val;  
   }
 }
 
@@ -1329,9 +1475,7 @@ class IncompleteValue extends IdentifiableValue {
   }
 //pragma endregion collapse
   toJSON() {
-    var val = {};
-    val[this._identifier.fqn] = super.toJSON();
-    return val;  
+    return {[this._identifier.fqn]: super.toJSON()};  
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -39,7 +39,7 @@ function sanityCheckModules(modelInfoMap) {
 function clearEmptyFields(object, iteratively = false) {
     Object.keys(object).forEach((key) => {
       if (object[key] == null) delete object[key]; else
-      if (object[key] instanceof Array && object[key].length == 0) delete object[key]; else
+      if (Array.isArray(object[key]) && object[key].length == 0) delete object[key]; else
       if (object[key] instanceof Object) {
         if (Object.keys(object[key]).length && iteratively) clearEmptyFields(object[key], true);
         if (!Object.keys(object[key]).length) delete object[key];
@@ -53,7 +53,7 @@ class Specifications {
     this._namespaces = new NamespaceSpecifications();
     this._dataElements = new DataElementSpecifications();
     this._valueSets = new ValueSetSpecifications();
-    this._codeSystems = new CodeSystemSpecifications();1
+    this._codeSystems = new CodeSystemSpecifications();
     this._maps = new MapSpecifications();
   }
 
@@ -386,7 +386,7 @@ class DataElement {
     this._basedOn = [];      // Identifier[]
     this._concepts = [];     // Concept[]
     this._fields = [];       // Value[] (and its subclasses) -- excluding primitive values
-    this._hierarchy = [];
+    this._hierarchy = [];    // String[], list of base class FQNs
     // also contains _value, _description, and _grammarVersion
   }
   // identifier is the unique Identifier (namespace+name) for the DataElement
@@ -517,12 +517,9 @@ class DataElement {
       "concepts":     this.concepts.map(c => c.toJSON()),
       "hierarchy":    this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
       "basedOn":      this.basedOn.map(b => b.fqn || b.toString()),
-      "value":        {},
-      "fields":       [],
+      "value":        this.value != null ? this.value.toJSON() : undefined,
+      "fields":       this._fields.map(f => f.toJSON()),
     };
-
-    output.value  = this.value != null ? this.value.toJSON() : undefined;
-    output.fields = this._fields.map(f => f.toJSON());
     
     clearEmptyFields(output, true)
     
@@ -531,9 +528,7 @@ class DataElement {
 }
 
 class Concept {
-
- 
-constructor(system, code, display) {
+  constructor(system, code, display) {
     this._system = system;
     this._code = code;
     this._display = display;
@@ -625,7 +620,7 @@ class Cardinality {
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
-    this._history = [];
+    this._history = []; // dictionary[] (min,max,source)
   }
 
   get min() { return this._min; }
@@ -931,7 +926,7 @@ class TypeConstraint extends Constraint {
 
   toJSON() {    
     return Object.assign({
-      "fqn": this._isA.fqn,
+      "fqn": this.isA.fqn,
       "onValue": this.onValue
     }, super.toJSON())
   }
@@ -939,18 +934,18 @@ class TypeConstraint extends Constraint {
 
 class IncludesTypeConstraint extends Constraint {
  
-  constructor(isA, card, path, isOnValue=false) {
+  constructor(isA, card, path, onValue=false) {
     super(path);
     this._isA = isA;
     this._card = card;
-    this._isOnValue=isOnValue;
+    this._onValue=onValue;
   }
 
   get isA() { return this._isA; }
   get card() { return this._card; }
-  get isOnValue() { return this._isOnValue; }
-  set isOnValue(isOnValue) {
-    this._isOnValue = isOnValue;
+  get onValue() { return this._onValue; }
+  set onValue(onValue) {
+    this._onValue = onValue;
   }
 
   clone() {
@@ -961,7 +956,7 @@ class IncludesTypeConstraint extends Constraint {
 
   equals(other) {
     return (other instanceof IncludesTypeConstraint) &&
-        this._isOnValue == other._isOnValue &&
+        this._onValue == other._onValue &&
         this._isA.equals(other.isA) &&
         this._card.equals(other.card) &&
         this._pathsAreEqual(other);
@@ -971,7 +966,7 @@ class IncludesTypeConstraint extends Constraint {
     return Object.assign({
       "fqn": this.isA.fqn,
       "card": this.card.toJSON(), 
-      "isOnValue": this.isOnValue
+      "onValue": this.onValue
     }, super.toJSON())
   }
 }
@@ -998,8 +993,7 @@ class CardConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();    
-    return Object.assign(this.card.toJSON(), constraint);
+    return Object.assign(this.card.toJSON(), super.toJSON());
   }
 }
 
@@ -1022,11 +1016,11 @@ class ConstraintsFilter {
   }
 
   get own() {
-    return new ConstraintsFilter(this._constraints.filter(c => c.path.length == 0 && (!c.onValue) && (!c.isOnValue)));
+    return new ConstraintsFilter(this._constraints.filter(c => c.path.length == 0 && (!c.onValue) && (!c.onValue)));
   }
 
   get child() {
-    return new ConstraintsFilter(this._constraints.filter(c => c.path.length > 0 || c.onValue || c.isOnValue));
+    return new ConstraintsFilter(this._constraints.filter(c => c.path.length > 0 || c.onValue || c.onValue));
   }
 
   get valueSet() {
@@ -1230,29 +1224,35 @@ class Value {
   }
  
   toJSON() {
-    let constraints = this._constraints.reduce((out, c, i, e) => {
-      let key = c.constructor.name.replace(/constraint/i, '').replace(/^[a-zA-Z]/, (s) => s.toLowerCase());
-      let cst = c.toJSON();
+    const constraints = this._constraints.reduce((out, constraint, i) => {
+      let key = constraint.constructor.name.replace(/constraint/i, '').replace(/^[a-zA-Z]/, (s) => s.toLowerCase());
+      let constraintJSON = constraint.toJSON();
 
-      let arrConstraints  = ['includesType', 'includesCode'];
-      let dicConstraints  = ['type', 'valueSet', 'card'];
-      let valConstraints  = ['boolean', 'code'];
+      const arrConstraints  = ['includesType', 'includesCode'];
+      const dicConstraints  = ['type', 'valueSet', 'card'];
+      const valConstraints  = ['boolean', 'code'];
       
-      var addToPath = (outputDict, skipCard=false) => {
+      const addToPath = (outputDict, skipCard=false) => {
         if (skipCard && key == 'card') return;
 
-        if (arrConstraints.includes(key)) (outputDict[key] == null ? outputDict[key] = [] : true) && outputDict[key].push(cst) ; else
-        if (dicConstraints.includes(key))  outputDict[key] = cst ; else
-        if (valConstraints.includes(key))  outputDict['fixedValue'] = cst;    
+        if (arrConstraints.includes(key)) {
+          if (outputDict[key] == null) outputDict[key] = [];
+
+          outputDict[key].push(constraintJSON);
+        } else if (dicConstraints.includes(key)) {
+          outputDict[key] = constraintJSON
+        } else if (valConstraints.includes(key)) {
+          outputDict['fixedValue'] = constraintJSON
+        }    
       }
 
-      if (c.path.length == 0) addToPath(out, true); else
-      if (c.path.length  > 0) {
+      if (constraint.path.length == 0) addToPath(out, true);
+      else if (constraint.path.length  > 0) {
         let currentSubField = out;
-        c.path.forEach((subP) => {
-          if (currentSubField['subpaths']           == null) currentSubField['subpaths']           = {};
+        constraint.path.forEach((subP) => {
+          if (currentSubField['subpaths'] == null) currentSubField['subpaths'] = {};
           if (currentSubField['subpaths'][subP.fqn] == null) currentSubField['subpaths'][subP.fqn] = {};
-          currentSubField = currentSubField['subpaths'][subP.fqn]; 
+          currentSubField = currentSubField['subpaths'][subP.fqn];
         })
         addToPath(currentSubField)
       }   
@@ -1334,8 +1334,6 @@ class IdentifiableValue extends Value {
     return Object.assign(
       {
         "fqn": this.identifier.fqn,
-        // "namespace": this.identifier.name,
-        // "name": this.identifier.name,  
       },
       super.toJSON()
     );  
@@ -1437,7 +1435,7 @@ class ChoiceValue extends Value {
   toJSON() {
     return Object.assign(super.toJSON(), {
       "options": this._options.map(v => {
-        let option = Object.assign({}, v.toJSON());
+        let option = v.toJSON();
         delete option["card"]
         return option
       })
@@ -1504,7 +1502,7 @@ class TBD extends Value{
   toJSON() {
     return Object.assign(
       {
-        "fqn" : this.text
+        "fqn" : this.toString()
       },
       super.toJSON()
     );
@@ -1640,7 +1638,7 @@ class ValueSet  {
   }
 
   toJSON() {
-    var rule = (ruleFilter) => ruleFilter._rules.map(r => r.toJSON());
+    const rule = (ruleFilter) => ruleFilter._rules.map(r => r.toJSON());
     var out = {
       "name":        this._identifier._name,
       "namespace":   this._identifier.namespace,
@@ -1950,6 +1948,7 @@ class ElementMapping {
   }
 
   toJSON() {
+    /* TODO: make field mappings hierarchial
     let fieldMappings = this.rulesFilter.field._rules.reduce((dict, m) => {      
       var paths = m.sourcePath.map(p => p.fqn).slice();
       var currDict = dict;
@@ -1964,7 +1963,8 @@ class ElementMapping {
 
       return dict;
     }, {})
-
+    */
+    
     let out = {
       "name": this.identifier.name,
       "namespace": this.identifier.namespace,
@@ -1974,7 +1974,7 @@ class ElementMapping {
       "mappings": {
         "fieldMapping": this.rulesFilter.field._rules.map(m => m.toJSON()), //TODO make hierarchial
         "cardMapping": this.rulesFilter.cardinality._rules.map(m => m.toJSON()),
-        "fixedValue": this.rulesFilter.fixedValue._rules.map(m => m.toJSON())
+        "fixedValueMapping": this.rulesFilter.fixedValue._rules.map(m => m.toJSON())
       }
     }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -645,6 +645,10 @@ class Cardinality {
   get max() { return this._max; }
   set max(max) { this._max = max; }
   // withMin is a convenience function for chaining
+
+  get history() { return this._history; }
+  set history(history) { this._history = history; }
+
   withMax(max) {
     this.max = max;
     return this;
@@ -706,6 +710,7 @@ class Constraint {
  
   constructor(path = []) {
     this._path = path;
+    this._lastModifiedBy = undefined;
   }
 
   get path() { return this._path; }
@@ -718,6 +723,9 @@ class Constraint {
   hasPath() {
     return this._path.length > 0;
   }
+
+  get lastModifiedBy() { return this._lastModifiedBy; }
+  set lastModifiedBy(lastModifiedBy) { this._lastModifiedBy = lastModifiedBy; }
 
 
   _clonePropertiesTo(clone) {
@@ -745,6 +753,7 @@ class Constraint {
     return true;
   }
 
+
   toJSON() {
     return {
       // "path": this._path.map(p => ({
@@ -752,7 +761,7 @@ class Constraint {
       //   "name": p._name,
       //   "fqn": p.fqn
       // })), 
-      // "type": this.constructor.name      
+      "lastModifiedBy": (this.lastModifiedBy) ? (this.lastModifiedBy.identifier ? this.lastModifiedBy.identifier.fqn : this.lastModifiedBy.text) : undefined,
     }
   }
 }
@@ -794,10 +803,11 @@ class ValueSetConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();
-    constraint["valueSet"] = this._valueSet;
-    constraint["bindingStrength"] = this._bindingStrength
-    return constraint;  
+    return Object.assign({
+      "valueSet": this._valueSet,
+      "bindingStrength": this._bindingStrength
+
+    }, super.toJSON());
   }
 }
 
@@ -824,20 +834,19 @@ class CodeConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();
-    constraint["type"]  = "code";
-    constraint["value"] = {
-      "system": this._code.system,
-      "code": this._code.code
-    }
-    delete constraint["path"];
-    return constraint;
+    return Object.assign({
+      "type": "code",
+      "value": {
+        "system": this._code.system,
+        "code": this._code.code
+      }
+    }, super.toJSON());
   }
 }
 
 // IncludesCodeConstraint only makes sense on an array of code or Coding
 class IncludesCodeConstraint extends Constraint {
- 
+
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -858,12 +867,10 @@ class IncludesCodeConstraint extends Constraint {
   }
   
   toJSON() {
-    var constraint = super.toJSON();
-    constraint["code"] = {
+    return Object.assign({
       "system": this._code.system,
       "code": this._code.code
-    }
-    return constraint;
+    }, super.toJSON());
   }
 }
 
@@ -891,10 +898,12 @@ class BooleanConstraint extends Constraint {
 
   toJSON() {
     var constraint = super.toJSON();
-    constraint["value"] = this._value
-    constraint["type"]  = "boolean";
     delete constraint["path"];
-    return constraint;
+    
+    return Object.assign({
+      "type": "boolean",
+      "value": this.value,
+    }, constraint);
   }
 }
 
@@ -933,13 +942,19 @@ class TypeConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();
-    constraint["subtype"] = {
-      "namespace": this._isA.namespace,
-      "name": this._isA.name
-    }
-    constraint["onValue"] = this._onValue;
-    return constraint;
+    // var constraint = super.toJSON();
+    // constraint["subtype"] = {
+    //   "namespace": this._isA.namespace,
+    //   "name": this._isA.name,
+    //   "fqn": this._isA.fqn
+    // }
+    // constraint["onValue"] = this._onValue;
+    // return constraint;
+    
+    return Object.assign({
+      "fqn": this._isA.fqn,
+      "onValue": this.onValue
+    }, super.toJSON())
   }
 }
 
@@ -974,14 +989,21 @@ class IncludesTypeConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();
-    constraint["isA"] = {
-      "namespace": this._isA.namespace,
-      "name": this._isA.name
-    }
-    constraint["card"] = this._card.toJSON();
-    constraint["isOnValue"] = this._isOnValue;
-    return constraint;
+    // var constraint = super.toJSON();
+    // constraint["isA"] = {
+    //   "namespace": this._isA.namespace,
+    //   "name": this._isA.name,
+    //   "fqn": this._isA.fqn
+    // }
+    // constraint["card"] = this._card.toJSON();
+    // constraint["isOnValue"] = this._isOnValue;
+    // return constraint;
+
+    return Object.assign({
+      "fqn": this.isA.fqn,
+      "card": this.card.toJSON(), 
+      "isOnValue": this.isOnValue
+    })
   }
 }
 
@@ -1007,9 +1029,9 @@ class CardConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = Object.assign(super.toJSON(), this._card.toJSON());
+    var constraint = super.toJSON();
     delete constraint["path"];    
-    return constraint;
+    return Object.assign(this.card.toJSON(), constraint);
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * An object that contains module information. Used to detect multiple versions of shr-models in a single environment.
  *
@@ -1235,7 +1236,7 @@ class Value {
         
         (skipCard) ? dicConstraints.pop() : null;
   
-        (arrConstraints.includes(key))  ? (outputDict[key] == null ? outputDict[key] == [] : true) && outputDict[key].push(cst)      :
+        (arrConstraints.includes(key))  ? (outputDict[key] == null ? outputDict[key] = [] : true) && outputDict[key].push(cst)      :
         (dicConstraints.includes(key))  ? outputDict[key] = cst          :
         (valConstraints.includes(key))  ? outputDict['fixedValue'] = cst : null;  
       }
@@ -1272,7 +1273,7 @@ class Value {
       } 
       return this.effectiveCard.toJSON()
     })() : "TBD";
-    
+
     return {
       "card": this.effectiveCard != null ? card : "TBD",
       "constraints": constraints,
@@ -1281,14 +1282,6 @@ class Value {
         "status": this._inheritance,
         "from": this._inheritedFrom.identifier != null ? this._inheritedFrom.identifier.fqn : undefined,
       }
-    }
-  }
-//pragma endregion collapse
-  toJSON() {
-    return {
-      "card": this._card != null ? this._card.toJSON() : "TBD",
-      "constraints": this._constraints.map(c => c),
-      "type": this.constructor.name,
     }
   }
 }
@@ -1956,6 +1949,38 @@ class ElementMapping {
 
     return clone;
   }
+
+  toJSON() {
+    let fieldMappings = this.rulesFilter.field._rules.reduce((dict, m) => {      
+      var paths = m.sourcePath.map(p => p.fqn).slice();
+      var currDict = dict;
+      while (paths.length > 0) {
+          let key = paths.shift();
+          if (!currDict[key]) {
+              currDict[key] = {};
+          }
+          currDict = currDict[key]
+      }
+      currDict["target"] = m.target;
+
+      return dict;
+    }, {})
+
+    let out = {
+      "name": this.identifier.name,
+      "namespace": this.identifier.namespace,
+      "fqn": this.identifier.fqn,
+      "target_spec": this.targetSpec,
+      "target_item": this.targetItem,
+      "mappings": {
+        "fieldMapping": this.rulesFilter.field._rules.map(m => m.toJSON()),
+        "cardMapping": this.rulesFilter.cardinality._rules.map(m => m.toJSON()),
+        "fixedValue": this.rulesFilter.fixedValue._rules.map(m => m.toJSON())
+      }
+    }
+
+    return out;
+  }
 }
 
 class FieldMappingRule {
@@ -1979,6 +2004,13 @@ class FieldMappingRule {
     const clonedSP = this._sourcePath.map(p => p.clone());
     return new FieldMappingRule(clonedSP, this._target);
   }
+
+  toJSON() {
+    return {
+      "target": this.target,
+      "sourcePath": this.sourcePath.map(s => s.fqn),
+    }
+  }
 }
 
 class CardinalityMappingRule {
@@ -1998,6 +2030,13 @@ class CardinalityMappingRule {
   clone() {
     return new CardinalityMappingRule(this._target, this._cardinality.clone());
   }
+
+  toJSON() {
+    return {
+      "target": this._target,
+      "cardinality": this._cardinality,
+    }
+  }
 }
 
 class FixedValueMappingRule {
@@ -2016,6 +2055,13 @@ class FixedValueMappingRule {
 
   clone() {
     return new FixedValueMappingRule(this._target, this._value);
+  }
+
+  toJSON() {
+    return {
+      "target": this._target,
+      "fixedValue": this._value,
+    }
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -511,6 +511,7 @@ class DataElement {
       "namespace": this.identifier.namespace,
       "isEntry": this.isEntry,
       "isAbstract": this.isAbstract,
+      "description": this.description,
       "concepts": this.concepts.map(c => c.toJSON()),
       "hierarchy": this._hierarchy.map(h => h.identifier.fqn), //fullish hierarchy
       "basedOn": this.basedOn.map(b => b.fqn),
@@ -1648,6 +1649,25 @@ class ValueSet  {
     }
     return clone;
   }
+
+  toJSON() {
+    var out = {
+      "name": this._identifier._name,
+      "namespace": this._identifier.namespace,
+      "description": this._description,
+      "concepts": this.concepts.map(c => c.toJSON()),
+      "url": this._url,
+      "values": this.rulesFilter.includesCode._rules.map(r => r.toJSON()),
+      "relationships": {
+        "includesDescendants":    this.rulesFilter.includesDescendents._rules.map(r => r.toJSON()),
+        "includesFromCode":       this.rulesFilter.includesFromCode._rules.map(r => r.toJSON()),
+        "includesFromCodeSystem": this.rulesFilter.includesFromCodeSystem._rules.map(r => r.toJSON()),
+        "excludesDescendants":    this.rulesFilter.excludesDescendents._rules.map(r => r.toJSON()),
+      }
+    }
+
+    return out;
+  }
 }
 
 // Note -- this should be consider abstract.  Do not instantiate!
@@ -1670,6 +1690,14 @@ class ValueSetIncludesCodeRule extends ValueSetCodeRule {
   clone() {
     return new ValueSetIncludesCodeRule(this._code.clone());
   }
+
+  toJSON() {
+    return {
+      "system": this._code.system,
+      "code": this._code.code,
+      "display": this._code.display
+    }
+  }
 }
 
 // ValueSetIncludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be included in the value set
@@ -1682,6 +1710,14 @@ class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
   clone() {
     return new ValueSetIncludesDescendentsRule(this._code.clone());
   }
+
+  toJSON() {
+    return {
+      "system": this._code.system,
+      "code": this._code.code,
+      "display": this._code.display
+    }
+  }
 }
 
 // ValueSetExcludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be excluded from the value set
@@ -1693,6 +1729,14 @@ class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
 
   clone() {
     return new ValueSetExcludesDescendentsRule(this._code.clone());
+  }
+
+  toJSON() {
+    return {
+      "system": this._code.system,
+      "code": this._code.code,
+      "display": this._code.display
+    }
   }
 }
 
@@ -1708,6 +1752,10 @@ class ValueSetIncludesFromCodeSystemRule {
   clone() {
     return new ValueSetIncludesFromCodeSystemRule(this._system);
   }
+
+  toJSON() {
+    return { "system": this._system };
+  }
 }
 
 // ValueSetIncludesFromCodeRule indicates that codes referenced by the given code should be included in the value set
@@ -1719,6 +1767,14 @@ class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
 
   clone() {
     return new ValueSetIncludesFromCodeRule(this._code.clone());
+  }
+
+  toJSON() {
+    return {
+      "system":   this._code.system,
+      "code":     this._code.code,
+      "display":  this._code.display
+    }
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * An object that contains module information. Used to detect multiple versions of shr-models in a single environment.
  *
@@ -138,12 +137,6 @@ class DataElementSpecifications {
   findByIdentifier(identifier) {
     return this.find(identifier.namespace, identifier.name);
   }
-
- 
-
-  // toJSON() {
-  
-  // }
 }
 
 class ValueSetSpecifications {
@@ -304,7 +297,7 @@ class MapSpecifications {
 }
 
 class TargetMapSpecifications {
- 
+
   constructor(target) {
     this._target = target;
     this._nsMap = new Map();
@@ -756,11 +749,6 @@ class Constraint {
 
   toJSON() {
     return {
-      // "path": this._path.map(p => ({
-      //   "namespace": p._namespace,
-      //   "name": p._name,
-      //   "fqn": p.fqn
-      // })), 
       "lastModifiedBy": (this.lastModifiedBy) ? (this.lastModifiedBy.identifier ? this.lastModifiedBy.identifier.fqn : this.lastModifiedBy.text) : undefined,
     }
   }
@@ -804,7 +792,7 @@ class ValueSetConstraint extends Constraint {
 
   toJSON() {
     return Object.assign({
-      "valueSet": this._valueSet,
+      "uri": this._valueSet,
       "bindingStrength": this._bindingStrength
 
     }, super.toJSON());
@@ -941,16 +929,7 @@ class TypeConstraint extends Constraint {
         this._pathsAreEqual(other);
   }
 
-  toJSON() {
-    // var constraint = super.toJSON();
-    // constraint["subtype"] = {
-    //   "namespace": this._isA.namespace,
-    //   "name": this._isA.name,
-    //   "fqn": this._isA.fqn
-    // }
-    // constraint["onValue"] = this._onValue;
-    // return constraint;
-    
+  toJSON() {    
     return Object.assign({
       "fqn": this._isA.fqn,
       "onValue": this.onValue
@@ -989,21 +968,11 @@ class IncludesTypeConstraint extends Constraint {
   }
 
   toJSON() {
-    // var constraint = super.toJSON();
-    // constraint["isA"] = {
-    //   "namespace": this._isA.namespace,
-    //   "name": this._isA.name,
-    //   "fqn": this._isA.fqn
-    // }
-    // constraint["card"] = this._card.toJSON();
-    // constraint["isOnValue"] = this._isOnValue;
-    // return constraint;
-
     return Object.assign({
       "fqn": this.isA.fqn,
       "card": this.card.toJSON(), 
       "isOnValue": this.isOnValue
-    })
+    }, super.toJSON())
   }
 }
 
@@ -1029,8 +998,7 @@ class CardConstraint extends Constraint {
   }
 
   toJSON() {
-    var constraint = super.toJSON();
-    delete constraint["path"];    
+    var constraint = super.toJSON();    
     return Object.assign(this.card.toJSON(), constraint);
   }
 }
@@ -1279,8 +1247,8 @@ class Value {
           if (currentSubField['subpaths']           == null) currentSubField['subpaths']           = {};
           if (currentSubField['subpaths'][subP.fqn] == null) currentSubField['subpaths'][subP.fqn] = {};
           currentSubField = currentSubField['subpaths'][subP.fqn]; 
-          addToPath(currentSubField)
         })
+        addToPath(currentSubField)
       }   
 
       return out;
@@ -1875,7 +1843,6 @@ class CodeSystem  {
   }
 
   clone() {
-//TODO: wed
     const clone = new CodeSystem(this._identifier, this._url);
     if (this._description) {
       clone._description = this._description;

--- a/lib/models.js
+++ b/lib/models.js
@@ -1255,14 +1255,14 @@ class Value {
     }, {}
     );
 
-    let card = (this.card != null && this.effectiveCard != null) ? (() => {
-      if (this.card != this.effectiveCard) this.effectiveCard._history = this.card._history;
-      return this.effectiveCard.toJSON()
-    })() : "TBD";
-
+    let card = this.effectiveCard;
+    if (this.card != null && this.effectiveCard != null && this.card != this.effectiveCard && this.card.history) {
+      card.history = this.card.history
+    }
+    
     return {
       "valueType": this.constructor.name,
-      "card": this.effectiveCard != null ? card : "TBD",
+      "card": (card) ? card.toJSON() : "TBD",
       "constraints": Object.keys(constraints).length > 0 ? constraints : undefined,
       "inheritance": (this._inheritance) ? {
         "status": this._inheritance,

--- a/lib/models.js
+++ b/lib/models.js
@@ -1152,8 +1152,8 @@ class Value {
     this._inheritedFrom = inheritedFrom;
   }
 
-  withInheritedFrom(parent) {
-    this.inheritedFrom = parent;
+  withInheritedFrom(inheritedFrom) {
+    this.inheritedFrom = inheritedFrom;
     return this;
   }
 
@@ -1172,6 +1172,9 @@ class Value {
     }
     if (this._inheritance) {
       clone._inheritance = this.inheritance;
+    }
+    if (this._inheritedFrom) {
+      clone._inheritedFrom = this.inheritance;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",

--- a/test/canon-json-test.js
+++ b/test/canon-json-test.js
@@ -1,0 +1,661 @@
+const { expect } = require('chai');
+const mdl = require('../index');
+const fs = require('fs');
+const path = require('path');
+
+
+describe('#CanonicalJSON.DataElements.core', () => {
+    it('should correctly generate a simple element', () => {
+        let de = new simpleDE('shr.test', 'SimpleElement', false, false);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleElement')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate a simple element with concept and description', () => {
+        let de = new simpleDE('shr.test', 'SimpleElement', false, false)
+            .withDescription('It is a simple element')
+            .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'));
+                
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleConceptAndDescription')
+                
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate a simple entry element', () => {
+        let de = new simpleDE('shr.test', 'SimpleEntry', true, false);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleEntry')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+        
+    });
+
+    it('should correctly generate a simple abstract element', () => {
+        let de = new simpleDE('shr.test', 'SimpleAbstract', false, true)
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleAbstract')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+    
+    it('should correctly generate a simple element with a reference', () => {
+        let string = new simpleDE('shr.test', 'Simple', false, false);
+        let de = new simpleDE('shr.test', 'SimpleReference', true, false)
+            .withValue(new mdl.RefValue(id('shr.test', 'Simple')).withMinMax(1, 1))
+            .withDescription('It is a reference to a simple element');
+        
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleReference')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate an element with a multi-string value', () => {
+        let de = new simpleDE('shr.test', 'MultiString', true, false)
+            .withDescription('It is a multi-string entry')
+            .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1));
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('MultiString')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+    
+    it('should correctly generate an element with multiple vocabularies', () => {
+        let de = new simpleDE('shr.test', 'Simple', true, false)
+            .withDescription('It is a multi-concept entry')
+            .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
+            .withConcept(new mdl.Concept('urn:iso:std:iso:4217', 'baz', 'Foobaz'))
+            .withConcept(new mdl.Concept('urn:oid:2.16.840.1.114222.4.11.826', 'bam', 'Foobam'));
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('MultipleVocabularies')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+
+    // it('should correctly generate elements based on other elements', () => {
+    //     let simple = new simpleDE('shr.test', 'Simple');
+    //     let simple2 = new simpleDE('shr.test', 'Simple2');
+        
+    //     let simpleBase = new mdl.DataElement(id('shr.test', 'simpleBase'), false, false)
+    //         .withConcept(new mdl.Concept('http://boo.org', 'far', undefined))
+    //         .withField(new mdl.IdentifiableValue('shr.test', 'Simple2').withCard(1));
+        
+    //     let simpleBasedOn = new mdl.DataElement(id('shr.test', 'simpleBasedOn'), false, false)
+    //         .withBasedOn(id('shr.test', 'SimpleBase'))
+    //         .withConcept(new mdl.Concept('http://boo.org', 'far', undefined))
+    //         .withValue(new mdl.IdentifiableValue('shr.test', 'Simple2').withCard(1));
+        
+    //         let outputJson = simpleBasedOn.toJSON();
+    //         let fixtureJson = importDataElementFixture('MultipleVocabularies')
+    
+    //         expect(outputJson).to.deep.equal({"fixtureJson":"hi"});
+    //     });
+
+    //it('should correctly generate elements based on TBDs', () => {});
+
+    it('should correctly generate an entry element with a coded value', () => {
+         let de = new simpleDE('shr.test', 'SimpleCoded', true, false)
+         .withValue(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1));      
+         
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixture('SimpleCoded')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+       
+    });    
+});
+
+describe('#DataElements.choices', () => {
+    it('should correctly generate simple choices on values', () => {
+        let de = new simpleDE('shr.test', 'SimpleChoice', true, false)
+            .withValue(new mdl.ChoiceValue().withMinMax(1,1)
+                .withOption(new mdl.IdentifiableValue(pid('date')).withMinMax(0,1))
+                .withOption(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0,1))
+                .withOption(new mdl.IdentifiableValue(id('other.ns', 'Simple2')).withMinMax(0,1)));
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['choices'], 'SimpleChoice')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate complex choices on values', () => {
+        let TESTVS = 'http://standardhealthrecord.org/test/vs'
+
+        let de = new simpleDE('shr.test', 'ComplexChoice', true, false)
+            .withValue(new mdl.ChoiceValue().withMinMax(0,1)
+                .withOption(new mdl.IdentifiableValue(pid('date'))
+                    .withMinMax(0, 1)
+                    .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo.org', 'date'))))
+                .withOption(new mdl.IdentifiableValue(id('other.ns', 'Simple2'))
+                    .withMinMax(0, 1)
+                    .withConstraint(new mdl.ValueSetConstraint(`${TESTVS}/Choice`)))
+                .withOption(new mdl.IdentifiableValue(id('shr.test', 'Simple'))
+                    .withMinMax(0, 1))
+            );
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['choices'], 'ComplexChoice')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate simple choices on fields', () => {
+        let de = new simpleDE('shr.test', 'SimpleChoiceField', true, false)
+            .withField(new mdl.ChoiceValue().withMinMax(1,1)
+                .withOption(new mdl.IdentifiableValue(pid('date')).withMinMax(0,1))
+                .withOption(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0,1))
+                .withOption(new mdl.IdentifiableValue(id('other.ns', 'Simple2')).withMinMax(0, 1)));
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['choices'], 'SimpleChoiceField')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate complex choices on fields', () => {
+        let TESTVS = 'http://standardhealthrecord.org/test/vs'
+
+        let de = new simpleDE('shr.test', 'ComplexChoiceField', true, false)
+            .withField(new mdl.ChoiceValue().withMinMax(0,1)
+                .withOption(new mdl.IdentifiableValue(pid('date')).withMinMax(0, 1)
+                    .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo.org', 'date'))))
+                .withOption(new mdl.IdentifiableValue(id('other.ns', 'Simple2')).withMinMax(0,1)
+                    .withConstraint(new mdl.ValueSetConstraint(`${TESTVS}/Choice`)))
+                .withOption(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1)));
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['choices'], 'ComplexChoiceField')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+});
+
+describe('#DataElements.constraints', () => {
+    //card constraints (expanded tests in expander tooling)
+    it('should correctly generate card constraint on field child', () => {
+        let simple = new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1)
+        let simple2 = new mdl.IdentifiableValue(id('shr.test', 'Simple2')).withMinMax(0, 1)
+            .withConstraint(new mdl.CardConstraint(new mdl.Cardinality(1, 2), [pid('string')]))
+        
+        let de = new mdl.DataElement(id('shr.test', 'CardConstraintOnFieldChild'), true, false)
+            .withField(simple)
+            .withField(simple2);
+        
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'cardConstraints'], 'CardConstraintOnFieldChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+        
+    it('should correctly generate card constraint on value child', () => {
+            let simple = new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1)
+                .withConstraint(new mdl.CardConstraint(new mdl.Cardinality(1, 2), [pid('string')]))
+        
+            let de = new mdl.DataElement(id('shr.test', 'CardConstraintOnValueChild'), true, false)
+                .withValue(simple);
+
+            let outputJson = de.toJSON();
+            let fixtureJson = importDataElementFixtureFromPath(['constraints', 'cardConstraints'], 'CardConstraintOnValueChild')
+
+            expect(outputJson).to.deep.equal(fixtureJson);
+        });
+
+
+    //code constraints
+    it('should correctly generate code constraint on field', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+        
+        let de = new mdl.DataElement(id('shr.test', 'CodeConstraintOnField'), true, false)
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1))
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(0, 1)
+                .withConstraint(new mdl.CodeConstraint(defaultCode, [pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'codeConstraints'], 'CodeConstraintOnField')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    })
+
+
+    it('should correctly generate code constraint on field child', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+        
+        let de = new mdl.DataElement(id('shr.test', 'CodeConstraintOnFieldChild'), true, false)
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1))
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'CodedFromValueSet')).withMinMax(0, 1)
+                .withConstraint(new mdl.CodeConstraint(defaultCode, [id('shr.test','Coding'), pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'codeConstraints'], 'CodeConstraintOnFieldChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    })
+
+    it('should correctly generate code constraint on value', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+        
+        let de = new mdl.DataElement(id('shr.test', 'CodeConstraintOnValue'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(1, 1)
+                .withConstraint(new mdl.CodeConstraint(defaultCode, [pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'codeConstraints'], 'CodeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    })
+
+    it('should correctly generate code constraint on value child', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+
+        let de = new mdl.DataElement(id('shr.test', 'CodeConstraintOnValueChild'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'CodedFromValueSet')).withMinMax(1, 1)
+                .withConstraint(new mdl.CodeConstraint(defaultCode, [id('shr.test','Coding'), pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'codeConstraints'], 'CodeConstraintOnValueChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    })
+
+    it('should correctly generate systemless code constraint on value', () => {
+        let defaultCode = new mdl.Concept(null, 'bar');
+
+        let de = new mdl.DataElement(id('shr.test', 'SystemlessCodeConstraintOnValue'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(1, 1)
+                .withConstraint(new mdl.CodeConstraint(defaultCode, [pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'codeConstraints'], 'SystemlessCodeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    //includesCode constraints    
+    
+
+    it('should correctly generate includesCode constraints on field', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+        
+        let de = new mdl.DataElement(id('shr.test', 'IncludesCodeConstraintOnValue'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(1)
+                .withConstraint(new mdl.IncludesCodeConstraint(defaultCode, [pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesCodeConstraints'], 'IncludesCodeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+
+    it('should correctly generate includesCode constraints on field child', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+        
+        let de = new mdl.DataElement(id('shr.test', 'IncludesCodeConstraintOnFieldChild'), true, false)
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1))
+            .withField(new mdl.IdentifiableValue(id('shr.test', 'MultiCodedFromValueSet')).withMinMax(0, 1)
+                .withConstraint(new mdl.IncludesCodeConstraint(defaultCode, [id('shr.test','Coding'), pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesCodeConstraints'], 'IncludesCodeConstraintOnFieldChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+
+    it('should correctly generate includesCode constraints on value', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesCodeConstraintOnValue'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(1)
+                .withConstraint(new mdl.IncludesCodeConstraint(defaultCode, [pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesCodeConstraints'], 'IncludesCodeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+
+    it('should correctly generate includesCode constraints on value child', () => {
+        let defaultCode = new mdl.Concept('http://foo.org', 'bar');
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesCodeConstraintOnValueChild'), true, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'MultiCodedFromValueSet')).withMinMax(1, 1)
+                .withConstraint(new mdl.IncludesCodeConstraint(defaultCode, [id('shr.test', 'Coding'), pid('code')]))
+            )
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesCodeConstraints'], 'IncludesCodeConstraintOnValueChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    //type constraints
+
+    it('should correctly generate type constraints on field', () => {
+        let simple = new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(0, 1)
+            .withConstraint(new mdl.TypeConstraint(id('shr.test', 'Simple2')))
+
+        let de = new mdl.DataElement(id('shr.test', 'TypeConstraintOnField'), true, false)
+            .withField(simple);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'typeConstraints'], 'TypeConstraintOnField')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate type constraints on field child', () => {
+        let simple = new mdl.IdentifiableValue(id('shr.test', 'Complex')).withMinMax(0, 1)
+            .withConstraint(new mdl.TypeConstraint(id('shr.test', 'Simple2'),[id('shr.test','Simple')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'TypeConstraintOnFieldChild'), true, false)
+            .withField(simple);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'typeConstraints'], 'TypeConstraintOnFieldChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate type constraints on field child value', () => {
+        let simple = new mdl.IdentifiableValue(id('shr.test', 'HasSimpleValue')).withMinMax(0, 1)
+            .withConstraint(new mdl.TypeConstraint(id('shr.test', 'Simple2'), [id('shr.test','Simple')], true))
+
+        let de = new mdl.DataElement(id('shr.test', 'TypeConstraintOnFieldValue'), true, false)
+            .withField(simple);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'typeConstraints'], 'TypeConstraintOnFieldValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate type constraints on value', () => {
+        let simple = new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1)
+            .withConstraint(new mdl.TypeConstraint(id('shr.test', 'Simple2')))
+
+        let de = new mdl.DataElement(id('shr.test', 'TypeConstraintOnValue'), true, false)
+            .withValue(simple);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'typeConstraints'], 'TypeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate type constraints on value child', () => {
+        let complex = new mdl.IdentifiableValue(id('shr.test', 'Complex')).withMinMax(1, 1)
+            .withConstraint(new mdl.TypeConstraint(id('shr.test', 'Simple2'),[id('shr.test','Simple')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'TypeConstraintOnValueChild'), true, false)
+            .withValue(complex);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'typeConstraints'], 'TypeConstraintOnValueChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    //includesType constraints
+
+    it('should correctly generate includesType constraints on field', () => {
+        let components = new mdl.IdentifiableValue(id('shr.test', 'Components')).withMinMax(1, 1)
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple2'), new mdl.Cardinality(0, 1), [id('shr.test', 'ObservationComponent')]))
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple3'), new mdl.Cardinality(1, 1), [id('shr.test', 'ObservationComponent')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesTypeConstraintOnField'), true, false)
+            .withField(components);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesTypeConstraints'], 'IncludesTypeConstraintOnField')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate includesType constraints on field child', () => {
+        let components = new mdl.IdentifiableValue(id('shr.test', 'Complex')).withMinMax(0, 1)
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple2'), new mdl.Cardinality(0, 1), [id('shr.test', 'Components'), id('shr.test', 'ObservationComponent')]))
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple3'), new mdl.Cardinality(1, 1), [id('shr.test', 'Components'), id('shr.test', 'ObservationComponent')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesTypeConstraintOnFieldChild'), true, false)
+            .withField(components);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesTypeConstraints'], 'IncludesTypeConstraintOnFieldChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate includesType constraints on value', () => {
+        let components = new mdl.IdentifiableValue(id('shr.test', 'Components')).withMinMax(1, 1)
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple2'), new mdl.Cardinality(0, 1), [id('shr.test', 'ObservationComponent')]))
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple3'), new mdl.Cardinality(1, 1), [id('shr.test', 'ObservationComponent')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesTypeConstraintOnValue'), true, false)
+            .withValue(components);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesTypeConstraints'], 'IncludesTypeConstraintOnValue')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate includesType constraints on value', () => {
+        let components = new mdl.IdentifiableValue(id('shr.test', 'Complex')).withMinMax(1, 1)
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple2'), new mdl.Cardinality(0, 1), [id('shr.test', 'Components'), id('shr.test', 'ObservationComponent')]))
+            .withConstraint(new mdl.IncludesTypeConstraint(id('shr.test', 'Simple3'), new mdl.Cardinality(1, 1), [id('shr.test', 'Components'), id('shr.test', 'ObservationComponent')]))
+
+        let de = new mdl.DataElement(id('shr.test', 'IncludesTypeConstraintOnValueChild'), true, false)
+            .withValue(components);
+
+        let outputJson = de.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'includesTypeConstraints'], 'IncludesTypeConstraintOnValueChild')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    //valueset constraints
+    it('should correctly generate valueset constraints with path', () => {
+        let TESTVS = 'http://standardhealthrecord.org/test/vs'
+
+        let codedFromVS = new simpleDE('shr.test', 'CodedWithCodeFromValueSet', false, false)
+            .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coding')).withMinMax(1, 1)
+            .withConstraint(new mdl.ValueSetConstraint(`${TESTVS}/Coded`, [pid('code')])));
+
+        let outputJson = codedFromVS.toJSON();
+        let fixtureJson = importDataElementFixtureFromPath(['constraints', 'valuesetConstraints'], 'CodedWithCodeFromValueSet')
+
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate an entry element with a coded value from valueset', () => {
+        let TESTVS = 'http://standardhealthrecord.org/test/vs'
+
+        let de = new simpleDE('shr.test', 'CodedFromValueSet', true, false)
+            .withValue(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1)
+                .withConstraint(new mdl.ValueSetConstraint(`${TESTVS}/Coded`)));
+
+       let outputJson = de.toJSON();
+       let fixtureJson = importDataElementFixtureFromPath(['constraints','valuesetConstraints'], 'CodedFromValueSet')
+
+       expect(outputJson).to.deep.equal(fixtureJson);
+   });
+
+
+});
+
+describe('#ValueSet', () => {
+
+    it('should correctly generate a basic VS', () => {
+        let vsName = 'BasicVS'
+        let defaultURL = `http://foo.org`
+
+        let vs = new mdl.ValueSet(id('shr.test', vsName), `${defaultURL}/vs/${vsName}`)
+            .withDescription('BasicVS')
+            .withConcept(new mdl.Concept('http://foo.org', "bar"))
+            .withRule(new mdl.ValueSetIncludesCodeRule({
+                "system": `${defaultURL}/test/cs/BasicCS`,
+                "code": "AA",
+                "display": "Foo",
+            }))
+            .withRule(new mdl.ValueSetIncludesCodeRule({
+                "system": `${defaultURL}/test/cs/BasicCS`,
+                "code": "AB",
+                "display": "Foo"
+            }));
+        
+
+        let outputJson = vs.toJSON();
+        let fixtureJson = importValueSetFixture(vsName)
+    
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate a VS defining external codesystem codes', () => { 
+        let vsName = 'ExternalCodeSystemVS'
+        let defaultURL = `http://foo.org`
+
+        let vs = new mdl.ValueSet(id('shr.test', vsName), `${defaultURL}/vs/${vsName}`)
+            .withRule(new mdl.ValueSetIncludesCodeRule({
+                "system": `http://boo.org`,
+                "code": "12345",
+                "display": "Foo",
+            }))
+
+        
+
+        let outputJson = vs.toJSON();
+        let fixtureJson = importValueSetFixture(vsName)
+    
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+    
+    it('should correctly generate an includes code from VS', () => { 
+        let vsName = 'IncludesCodeFromCodeVS'
+        let defaultURL = `http://foo.org`
+
+        let vs = new mdl.ValueSet(id('shr.test', vsName), `${defaultURL}/vs/${vsName}`)
+            .withRule(new mdl.ValueSetIncludesFromCodeRule({
+                "system": defaultURL,
+                "code": "12345",
+            }));
+        
+
+        let outputJson = vs.toJSON();
+        let fixtureJson = importValueSetFixture(vsName)
+    
+        expect(outputJson).to.deep.equal(fixtureJson);
+    });
+
+    it('should correctly generate an includes code from codesystem VS', () => { 
+        let vsName = 'IncludesCodeFromCodesystemVS'
+        let defaultURL = `http://foo.org`
+
+        let vs = new mdl.ValueSet(id('shr.test', vsName), `${defaultURL}/vs/${vsName}`)
+            .withRule(new mdl.ValueSetIncludesFromCodeSystemRule(defaultURL));
+        
+
+        let outputJson = vs.toJSON();
+        let fixtureJson = importValueSetFixture(vsName)
+    
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+
+
+    it('should correctly generate a descending and not descending from VS', () => { 
+        let vsName = 'DescendingAndNotVS'
+        let defaultURL = `http://foo.org`
+
+        let vs = new mdl.ValueSet(id('shr.test', vsName), `${defaultURL}/vs/${vsName}`)
+            .withRule(new mdl.ValueSetIncludesDescendentsRule({
+                "system": defaultURL,
+                "code": "12345",
+            }))
+            .withRule(new mdl.ValueSetExcludesDescendentsRule({
+                "system": defaultURL,
+                "code": "54321",
+            }));
+        
+
+        let outputJson = vs.toJSON();
+        let fixtureJson = importValueSetFixture(vsName)
+    
+        expect(outputJson).to.deep.equal(fixtureJson);
+
+    });
+
+});
+
+
+//import fixture
+
+function importDataElementFixture(name) {
+    return importJSONFromFilePath(`dataelements/${name}.json`);
+}
+
+function importValueSetFixture(name) {
+    return importJSONFromFilePath(`valuesets/${name}.json`);
+}
+
+function importDataElementFixtureFromPath(path, name) {
+    return importJSONFromFilePath(`dataelements/${path.join('/')}/${name}.json`);
+}
+  
+//   function importFixtureFolder(name, numExpectedErrors = 0) {
+//     const dependencies = importFromFilePath(`${__dirname}/fixtures/dataElement/_dependencies`);
+//     const specifications = importFromFilePath(`${__dirname}/fixtures/dataElement/${name}`, null, dependencies);
+//     expect(err.errors().length).to.equal(numExpectedErrors);
+//     return specifications;
+//   }
+
+function importJSONFromFilePath(path) {
+    let filePath = `${__dirname}/fixtures/${path}`;
+    let file = fs.readFileSync(filePath, 'utf8');
+    var json = JSON.parse(file);
+  
+    return json;
+}
+
+// Shorthand Identifier constructor for more concise code
+function id(namespace, name) {
+    return new mdl.Identifier(namespace, name);
+  }
+  
+  // Shorthand PrimitiveIdentifier constructor for more concise code
+  function pid(name) {
+    return new mdl.PrimitiveIdentifier(name);
+  }
+  
+  // Creates a simple element, mainly used to satisfy referential integrity
+  function simpleDE(namespace, name, isEntry=false, isAbstract=false) {
+      let de = new mdl.DataElement(id(namespace, name), isEntry, isAbstract)
+          .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));      
+    return de;
+  }
+  

--- a/test/fixtures/dataelements/MultiString.json
+++ b/test/fixtures/dataelements/MultiString.json
@@ -1,0 +1,15 @@
+{
+    "name": "MultiString",
+    "namespace": "shr.test",
+    "fqn": "shr.test.MultiString",
+    "isEntry": true,
+    "isAbstract": false,
+    "description": "It is a multi-string entry",
+    "value": {
+        "fqn": "string",
+        "valueType": "IdentifiableValue",
+        "card": {
+            "min": 1
+        }
+    }
+}

--- a/test/fixtures/dataelements/MultipleVocabularies.json
+++ b/test/fixtures/dataelements/MultipleVocabularies.json
@@ -1,0 +1,33 @@
+{
+    "name": "Simple",
+    "namespace": "shr.test",
+    "fqn": "shr.test.Simple",
+    "isEntry": true,
+    "isAbstract": false,
+    "description": "It is a multi-concept entry",
+    "concepts": [
+      {
+        "system": "http://foo.org",
+        "code": "bar",
+        "display": "Foobar"
+      },
+      {
+        "system": "urn:iso:std:iso:4217",
+        "code": "baz",
+        "display": "Foobaz"
+      },
+      {
+        "system": "urn:oid:2.16.840.1.114222.4.11.826",
+        "code": "bam",
+        "display": "Foobam"
+      }
+    ],
+    "value": {
+      "fqn": "string",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 1,
+        "max": 1
+      }
+    }
+  }

--- a/test/fixtures/dataelements/SimpleAbstract.json
+++ b/test/fixtures/dataelements/SimpleAbstract.json
@@ -1,0 +1,15 @@
+{
+  "name": "SimpleAbstract",
+  "namespace": "shr.test",
+  "fqn": "shr.test.SimpleAbstract",
+  "isEntry": false,
+  "isAbstract": true,
+  "value": {
+    "fqn": "string",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    }
+  }
+}

--- a/test/fixtures/dataelements/SimpleCoded.json
+++ b/test/fixtures/dataelements/SimpleCoded.json
@@ -1,0 +1,15 @@
+{
+  "name": "SimpleCoded",
+  "namespace": "shr.test",
+  "fqn": "shr.test.SimpleCoded",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "code",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    }
+  }
+}

--- a/test/fixtures/dataelements/SimpleConceptAndDescription.json
+++ b/test/fixtures/dataelements/SimpleConceptAndDescription.json
@@ -1,0 +1,23 @@
+{
+    "name": "SimpleElement",
+    "namespace": "shr.test",
+    "fqn": "shr.test.SimpleElement",
+    "isEntry": false,
+    "isAbstract": false,
+    "description": "It is a simple element",
+    "concepts": [
+      {
+        "system": "http://foo.org",
+        "code": "bar",
+        "display": "Foobar"
+      }
+    ],
+    "value": {
+      "fqn": "string",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 1,
+        "max": 1
+      }
+    }
+  }

--- a/test/fixtures/dataelements/SimpleElement.json
+++ b/test/fixtures/dataelements/SimpleElement.json
@@ -1,0 +1,15 @@
+{
+  "name": "SimpleElement",
+  "namespace": "shr.test",
+  "fqn": "shr.test.SimpleElement",
+  "isEntry": false,
+  "isAbstract": false,
+  "value": {
+    "fqn": "string",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    }
+  }
+}

--- a/test/fixtures/dataelements/SimpleEntry.json
+++ b/test/fixtures/dataelements/SimpleEntry.json
@@ -1,0 +1,15 @@
+{
+  "name": "SimpleEntry",
+  "namespace": "shr.test",
+  "fqn": "shr.test.SimpleEntry",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "string",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    }
+  }
+}

--- a/test/fixtures/dataelements/SimpleReference.json
+++ b/test/fixtures/dataelements/SimpleReference.json
@@ -1,0 +1,16 @@
+{
+    "name": "SimpleReference",
+    "namespace": "shr.test",
+    "fqn": "shr.test.SimpleReference",
+    "isEntry": true,
+    "isAbstract": false,
+    "description": "It is a reference to a simple element",
+    "value": {
+      "fqn": "shr.test.Simple",
+      "valueType": "RefValue",
+      "card": {
+        "min": 1,
+        "max": 1
+      }
+    }
+  }

--- a/test/fixtures/dataelements/basedon/OptionalValue.json
+++ b/test/fixtures/dataelements/basedon/OptionalValue.json
@@ -1,0 +1,15 @@
+{
+    "name": "OptionalValue",
+    "namespace": "shr.test",
+    "fqn": "shr.test.OptionalValue",
+    "isEntry": true,
+    "isAbstract": false,
+    "value": {
+      "fqn": "string",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    }
+  }

--- a/test/fixtures/dataelements/basedon/ZeroedOutValue.json
+++ b/test/fixtures/dataelements/basedon/ZeroedOutValue.json
@@ -1,0 +1,32 @@
+{
+    "name": "ZeroedOutValue",
+    "namespace": "shr.test",
+    "fqn": "shr.test.ZeroedOutValue",
+    "isEntry": true,
+    "isAbstract": false,
+    "hierarchy": [
+      "shr.test.OptionalValue"
+    ],
+    "basedOn": [
+      "shr.test.OptionalValue"
+    ],
+    "value": {
+      "fqn": "string",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 0,
+        "history": [
+          {
+            "source": "shr.test.OptionalValue",
+            "min": 0,
+            "max": 1
+          }
+        ]
+      },
+      "inheritance": {
+        "status": "overridden",
+        "from": "shr.test.OptionalValue"
+      }
+    }
+  }

--- a/test/fixtures/dataelements/choices/ComplexChoice.json
+++ b/test/fixtures/dataelements/choices/ComplexChoice.json
@@ -1,0 +1,43 @@
+{
+  "name": "ComplexChoice",
+  "namespace": "shr.test",
+  "fqn": "shr.test.ComplexChoice",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "valueType": "ChoiceValue",
+    "card": {
+      "min": 0,
+      "max": 1
+    },
+    "options": [
+      {
+        "fqn": "date",
+        "valueType": "IdentifiableValue",
+        "constraints": {
+          "fixedValue": {
+            "type": "code",
+            "value": {
+              "system": "http://foo.org",
+              "code": "date"
+            }
+          }
+        }
+      },
+      {
+        "fqn": "other.ns.Simple2",
+        "valueType": "IdentifiableValue",
+        "constraints": {
+          "valueSet": {
+            "uri": "http://standardhealthrecord.org/test/vs/Choice",
+            "bindingStrength": "REQUIRED"
+          }
+        }
+      },
+      {
+        "fqn": "shr.test.Simple",
+        "valueType": "IdentifiableValue"
+      }
+    ]
+  }
+}

--- a/test/fixtures/dataelements/choices/ComplexChoiceField.json
+++ b/test/fixtures/dataelements/choices/ComplexChoiceField.json
@@ -1,0 +1,53 @@
+{
+    "name": "ComplexChoiceField",
+    "namespace": "shr.test",
+    "fqn": "shr.test.ComplexChoiceField",
+    "isEntry": true,
+    "isAbstract": false,
+    "value": {
+        "fqn": "string",
+        "valueType": "IdentifiableValue",
+        "card": {
+          "min": 1,
+          "max": 1
+        }
+      },
+    "fields": [
+      {
+        "valueType": "ChoiceValue",
+        "card": {
+          "min": 0,
+          "max": 1
+        },
+        "options": [
+          {
+            "fqn": "date",
+            "valueType": "IdentifiableValue",
+            "constraints": {
+              "fixedValue": {
+                "type": "code",
+                "value": {
+                  "system": "http://foo.org",
+                  "code": "date"
+                }
+              }
+            }
+          },
+          {
+            "fqn": "other.ns.Simple2",
+            "valueType": "IdentifiableValue",
+            "constraints": {
+              "valueSet": {
+                "uri": "http://standardhealthrecord.org/test/vs/Choice",
+                "bindingStrength": "REQUIRED"
+              }
+            }
+          },
+          {
+            "fqn": "shr.test.Simple",
+            "valueType": "IdentifiableValue"
+          }
+        ]
+      }
+    ]
+  }

--- a/test/fixtures/dataelements/choices/SimpleChoice.json
+++ b/test/fixtures/dataelements/choices/SimpleChoice.json
@@ -1,0 +1,28 @@
+{
+    "name": "SimpleChoice",
+    "namespace": "shr.test",
+    "fqn": "shr.test.SimpleChoice",
+    "isEntry": true,
+    "isAbstract": false,
+    "value": {
+      "valueType": "ChoiceValue",
+      "card": {
+        "min": 1,
+        "max": 1
+      },
+      "options": [
+        {
+          "fqn": "date",
+          "valueType": "IdentifiableValue"
+        },
+        {
+          "fqn": "shr.test.Simple",
+          "valueType": "IdentifiableValue"
+        },
+        {
+          "fqn": "other.ns.Simple2",
+          "valueType": "IdentifiableValue"
+        }
+      ]
+    }
+  }

--- a/test/fixtures/dataelements/choices/SimpleChoiceField.json
+++ b/test/fixtures/dataelements/choices/SimpleChoiceField.json
@@ -1,0 +1,38 @@
+{
+    "name": "SimpleChoiceField",
+    "namespace": "shr.test",
+    "fqn": "shr.test.SimpleChoiceField",
+    "isEntry": true,
+    "isAbstract": false,
+    "value": {
+        "fqn": "string",
+        "valueType": "IdentifiableValue",
+        "card": {
+          "min": 1,
+          "max": 1
+        }
+      },
+    "fields": [
+        {
+            "valueType": "ChoiceValue",
+            "card": {
+                "min": 1,
+                "max": 1
+            },
+            "options": [
+                {
+                    "fqn": "date",
+                    "valueType": "IdentifiableValue"
+                },
+                {
+                    "fqn": "shr.test.Simple",
+                    "valueType": "IdentifiableValue"
+                },
+                {
+                    "fqn": "other.ns.Simple2",
+                    "valueType": "IdentifiableValue"
+                }
+            ]
+        }
+    ]
+}

--- a/test/fixtures/dataelements/constraints/cardConstraints/CardConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/cardConstraints/CardConstraintOnFieldChild.json
@@ -1,0 +1,35 @@
+{
+  "name": "CardConstraintOnFieldChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CardConstraintOnFieldChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    {
+      "fqn": "shr.test.Simple2",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "string": {
+            "card": {
+              "min": 1,
+              "max": 2
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/cardConstraints/CardConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/cardConstraints/CardConstraintOnValueChild.json
@@ -1,0 +1,25 @@
+{
+  "name": "CardConstraintOnValueChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CardConstraintOnValueChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Simple",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "string": {
+          "card": {
+            "min": 1,
+            "max": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnField.json
+++ b/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnField.json
@@ -1,0 +1,38 @@
+{
+  "name": "CodeConstraintOnField",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodeConstraintOnField",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    {
+      "fqn": "shr.test.Coding",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "code": {
+            "fixedValue": {
+              "type": "code",
+              "value": {
+                "system": "http://foo.org",
+                "code": "bar"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnFieldChild.json
@@ -1,0 +1,42 @@
+{
+  "name": "CodeConstraintOnFieldChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodeConstraintOnFieldChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    {
+      "fqn": "shr.test.CodedFromValueSet",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "shr.test.Coding": {
+            "subpaths": {
+              "code": {
+                "fixedValue": {
+                  "type": "code",
+                  "value": {
+                    "system": "http://foo.org",
+                    "code": "bar"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnValue.json
@@ -1,0 +1,28 @@
+{
+  "name": "CodeConstraintOnValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodeConstraintOnValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Coding",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "code": {
+          "fixedValue": {
+            "type": "code",
+            "value": {
+              "system": "http://foo.org",
+              "code": "bar"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/codeConstraints/CodeConstraintOnValueChild.json
@@ -1,0 +1,32 @@
+{
+  "name": "CodeConstraintOnValueChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodeConstraintOnValueChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.CodedFromValueSet",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.Coding": {
+          "subpaths": {
+            "code": {
+              "fixedValue": {
+                "type": "code",
+                "value": {
+                  "system": "http://foo.org",
+                  "code": "bar"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/codeConstraints/SystemlessCodeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/codeConstraints/SystemlessCodeConstraintOnValue.json
@@ -1,0 +1,27 @@
+{
+  "name": "SystemlessCodeConstraintOnValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.SystemlessCodeConstraintOnValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Coding",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "code": {
+          "fixedValue": {
+            "type": "code",
+            "value": {
+              "code": "bar"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnField.json
+++ b/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnField.json
@@ -1,0 +1,36 @@
+{
+  "name": "IncludesCodeConstraintOnField",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeConstraintOnField",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    {
+      "fqn": "shr.test.Coding",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "code": {
+            "includesCode": [
+              {
+                "system": "http://foo.org",
+                "code": "bar"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnFieldChild.json
@@ -1,0 +1,41 @@
+{
+  "name": "IncludesCodeConstraintOnFieldChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeConstraintOnFieldChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    {
+      "fqn": "shr.test.MultiCodedFromValueSet",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "shr.test.Coding": {
+            "subpaths": {
+              "code": {
+                "includesCode": [
+                  {
+                    "system": "http://foo.org",
+                    "code": "bar"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnValue.json
@@ -1,0 +1,26 @@
+{
+  "name": "IncludesCodeConstraintOnValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeConstraintOnValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Coding",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "code": {
+          "includesCode": [
+            {
+              "system": "http://foo.org",
+              "code": "bar"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/includesCodeConstraints/IncludesCodeConstraintOnValueChild.json
@@ -1,0 +1,31 @@
+{
+  "name": "IncludesCodeConstraintOnValueChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeConstraintOnValueChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.MultiCodedFromValueSet",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.Coding": {
+          "subpaths": {
+            "code": {
+              "includesCode": [
+                {
+                  "system": "http://foo.org",
+                  "code": "bar"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesCodeConstraints/MultiCodedFromValueSet.json
+++ b/test/fixtures/dataelements/constraints/includesCodeConstraints/MultiCodedFromValueSet.json
@@ -1,0 +1,25 @@
+{
+  "name": "MultiCodedFromValueSet",
+  "namespace": "shr.test",
+  "fqn": "shr.test.MultiCodedFromValueSet",
+  "isEntry": false,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Coding",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "code": {
+          "valueSet": {
+            "uri": "http://standardhealthrecord.org/test/vs/Coded",
+            "bindingStrength": "REQUIRED",
+            "lastModifiedBy": "shr.test.MultiCodedFromValueSet"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnField.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnField.json
@@ -1,0 +1,39 @@
+{
+  "name": "IncludesTypeConstraintOnField",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesTypeConstraintOnField",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [{
+    "fqn": "shr.test.Components",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.ObservationComponent": {
+          "includesType": [
+            {
+              "fqn": "shr.test.Simple2",
+              "card": {
+                "min": 0,
+                "max": 1
+              },
+              "isOnValue": false
+            },
+            {
+              "fqn": "shr.test.Simple3",
+              "card": {
+                "min": 1,
+                "max": 1
+              },
+              "isOnValue": false
+            }
+          ]
+        }
+      }
+    }
+  }]
+}

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnField.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnField.json
@@ -21,7 +21,7 @@
                 "min": 0,
                 "max": 1
               },
-              "isOnValue": false
+              "onValue": false
             },
             {
               "fqn": "shr.test.Simple3",
@@ -29,7 +29,7 @@
                 "min": 1,
                 "max": 1
               },
-              "isOnValue": false
+              "onValue": false
             }
           ]
         }

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnFieldChild.json
@@ -24,7 +24,7 @@
                       "min": 0,
                       "max": 1
                     },
-                    "isOnValue": false
+                    "onValue": false
                   },
                   {
                     "fqn": "shr.test.Simple3",
@@ -32,7 +32,7 @@
                       "min": 1,
                       "max": 1
                     },
-                    "isOnValue": false
+                    "onValue": false
                   }
                 ]
               }

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnFieldChild.json
@@ -1,0 +1,45 @@
+{
+  "name": "IncludesTypeConstraintOnFieldChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesTypeConstraintOnFieldChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Complex",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "shr.test.Components": {
+            "subpaths": {
+              "shr.test.ObservationComponent": {
+                "includesType": [
+                  {
+                    "fqn": "shr.test.Simple2",
+                    "card": {
+                      "min": 0,
+                      "max": 1
+                    },
+                    "isOnValue": false
+                  },
+                  {
+                    "fqn": "shr.test.Simple3",
+                    "card": {
+                      "min": 1,
+                      "max": 1
+                    },
+                    "isOnValue": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValue.json
@@ -1,0 +1,39 @@
+{
+  "name": "IncludesTypeConstraintOnValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesTypeConstraintOnValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Components",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.ObservationComponent": {
+          "includesType": [
+            {
+              "fqn": "shr.test.Simple2",
+              "card": {
+                "min": 0,
+                "max": 1
+              },
+              "isOnValue": false
+            },
+            {
+              "fqn": "shr.test.Simple3",
+              "card": {
+                "min": 1,
+                "max": 1
+              },
+              "isOnValue": false
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValue.json
@@ -21,7 +21,7 @@
                 "min": 0,
                 "max": 1
               },
-              "isOnValue": false
+              "onValue": false
             },
             {
               "fqn": "shr.test.Simple3",
@@ -29,7 +29,7 @@
                 "min": 1,
                 "max": 1
               },
-              "isOnValue": false
+              "onValue": false
             }
           ]
         }

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValueChild.json
@@ -1,0 +1,43 @@
+{
+  "name": "IncludesTypeConstraintOnValueChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesTypeConstraintOnValueChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Complex",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.Components": {
+          "subpaths": {
+            "shr.test.ObservationComponent": {
+              "includesType": [
+                {
+                  "fqn": "shr.test.Simple2",
+                  "card": {
+                    "min": 0,
+                    "max": 1
+                  },
+                  "isOnValue": false
+                },
+                {
+                  "fqn": "shr.test.Simple3",
+                  "card": {
+                    "min": 1,
+                    "max": 1
+                  },
+                  "isOnValue": false
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/includesTypeConstraints/IncludesTypeConstraintOnValueChild.json
@@ -23,7 +23,7 @@
                     "min": 0,
                     "max": 1
                   },
-                  "isOnValue": false
+                  "onValue": false
                 },
                 {
                   "fqn": "shr.test.Simple3",
@@ -31,7 +31,7 @@
                     "min": 1,
                     "max": 1
                   },
-                  "isOnValue": false
+                  "onValue": false
                 }
               ]
             }

--- a/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnField.json
+++ b/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnField.json
@@ -1,0 +1,23 @@
+{
+  "name": "TypeConstraintOnField",
+  "namespace": "shr.test",
+  "fqn": "shr.test.TypeConstraintOnField",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Simple",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "type": {
+          "fqn": "shr.test.Simple2",
+          "onValue": false
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnFieldChild.json
+++ b/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnFieldChild.json
@@ -1,0 +1,27 @@
+{
+  "name": "TypeConstraintOnFieldChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.TypeConstraintOnFieldChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.Complex",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "shr.test.Simple": {
+            "type": {
+              "fqn": "shr.test.Simple2",
+              "onValue": false
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnFieldValue.json
+++ b/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnFieldValue.json
@@ -1,0 +1,27 @@
+{
+  "name": "TypeConstraintOnFieldValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.TypeConstraintOnFieldValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "fields": [
+    {
+      "fqn": "shr.test.HasSimpleValue",
+      "valueType": "IdentifiableValue",
+      "card": {
+        "min": 0,
+        "max": 1
+      },
+      "constraints": {
+        "subpaths": {
+          "shr.test.Simple": {
+            "type": {
+              "fqn": "shr.test.Simple2",
+              "onValue": true
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnValue.json
+++ b/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnValue.json
@@ -1,0 +1,21 @@
+{
+  "name": "TypeConstraintOnValue",
+  "namespace": "shr.test",
+  "fqn": "shr.test.TypeConstraintOnValue",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Simple",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "type": {
+        "fqn": "shr.test.Simple2",
+        "onValue": false
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnValueChild.json
+++ b/test/fixtures/dataelements/constraints/typeConstraints/TypeConstraintOnValueChild.json
@@ -1,0 +1,25 @@
+{
+  "name": "TypeConstraintOnValueChild",
+  "namespace": "shr.test",
+  "fqn": "shr.test.TypeConstraintOnValueChild",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Complex",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "shr.test.Simple": {
+          "type": {
+            "fqn": "shr.test.Simple2",
+            "onValue": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/valuesetConstraints/CodedFromValueSet.json
+++ b/test/fixtures/dataelements/constraints/valuesetConstraints/CodedFromValueSet.json
@@ -1,0 +1,21 @@
+{
+  "name": "CodedFromValueSet",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodedFromValueSet",
+  "isEntry": true,
+  "isAbstract": false,
+  "value": {
+    "fqn": "code",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "valueSet": {
+        "uri": "http://standardhealthrecord.org/test/vs/Coded",
+        "bindingStrength": "REQUIRED"
+      }
+    }
+  }
+}

--- a/test/fixtures/dataelements/constraints/valuesetConstraints/CodedWithCodeFromValueSet.json
+++ b/test/fixtures/dataelements/constraints/valuesetConstraints/CodedWithCodeFromValueSet.json
@@ -1,0 +1,25 @@
+{
+  "name": "CodedWithCodeFromValueSet",
+  "namespace": "shr.test",
+  "fqn": "shr.test.CodedWithCodeFromValueSet",
+  "isEntry": false,
+  "isAbstract": false,
+  "value": {
+    "fqn": "shr.test.Coding",
+    "valueType": "IdentifiableValue",
+    "card": {
+      "min": 1,
+      "max": 1
+    },
+    "constraints": {
+      "subpaths": {
+        "code": {
+          "valueSet": {
+            "uri": "http://standardhealthrecord.org/test/vs/Coded",
+            "bindingStrength": "REQUIRED"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/namespaces/shr-test.json
+++ b/test/fixtures/namespaces/shr-test.json
@@ -1,0 +1,4 @@
+{
+  "name": "shr.test",
+  "description": "Simple Namespace"
+}

--- a/test/fixtures/valuesets/BasicVS.json
+++ b/test/fixtures/valuesets/BasicVS.json
@@ -1,0 +1,25 @@
+{
+  "name": "BasicVS",
+  "namespace": "shr.test",
+  "fqn": "shr.test.BasicVS",
+  "description": "BasicVS",  
+  "concepts": [
+    {
+      "system": "http://foo.org",
+      "code": "bar"
+    }
+  ],
+  "url": "http://foo.org/vs/BasicVS",
+  "values": [
+    {
+      "system": "http://foo.org/test/cs/BasicCS",
+      "code": "AA",
+      "description": "Foo"
+    },
+    {
+      "system": "http://foo.org/test/cs/BasicCS",
+      "code": "AB",
+      "description": "Foo"
+    }
+  ]
+}

--- a/test/fixtures/valuesets/DescendingAndNotVS.json
+++ b/test/fixtures/valuesets/DescendingAndNotVS.json
@@ -1,0 +1,20 @@
+{
+  "name": "DescendingAndNotVS",
+  "namespace": "shr.test",
+  "fqn": "shr.test.DescendingAndNotVS",
+  "url": "http://foo.org/vs/DescendingAndNotVS",
+  "rules": {
+    "includesDescendants": [
+      {
+        "system": "http://foo.org",
+        "code": "12345"
+      }
+    ],
+    "excludesDescendants": [
+      {
+        "system": "http://foo.org",
+        "code": "54321"
+      }
+    ]
+  }
+}

--- a/test/fixtures/valuesets/ExternalCodeSystemVS.json
+++ b/test/fixtures/valuesets/ExternalCodeSystemVS.json
@@ -1,0 +1,13 @@
+{
+  "name": "ExternalCodeSystemVS",
+  "namespace": "shr.test",
+  "fqn": "shr.test.ExternalCodeSystemVS",
+  "url": "http://foo.org/vs/ExternalCodeSystemVS",
+  "values": [
+    {
+      "system": "http://boo.org",
+      "code": "12345",
+      "description": "Foo"
+    }
+  ]
+}

--- a/test/fixtures/valuesets/IncludesCodeFromCodeVS.json
+++ b/test/fixtures/valuesets/IncludesCodeFromCodeVS.json
@@ -1,0 +1,14 @@
+{
+  "name": "IncludesCodeFromCodeVS",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeFromCodeVS",
+  "url": "http://foo.org/vs/IncludesCodeFromCodeVS",
+  "rules": {
+    "includesFromCode": [
+      {
+        "system": "http://foo.org",
+        "code": "12345"
+      }
+    ]
+  }
+}

--- a/test/fixtures/valuesets/IncludesCodeFromCodesystemVS.json
+++ b/test/fixtures/valuesets/IncludesCodeFromCodesystemVS.json
@@ -1,0 +1,13 @@
+{
+  "name": "IncludesCodeFromCodesystemVS",
+  "namespace": "shr.test",
+  "fqn": "shr.test.IncludesCodeFromCodesystemVS",
+  "url": "http://foo.org/vs/IncludesCodeFromCodesystemVS",
+  "rules": {
+    "includesFromCodeSystem": [
+      {
+        "system": "http://foo.org"
+      }
+    ]
+  }
+}

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -317,7 +317,7 @@ describe('#ChoiceValue', () => {
 
   it('should be properly identified as the effective value on a constrained element', () => {
     // TODO: Perhaps this should be moved to a separate suite for ConstraintsFilter.
-    // TODO: We should also test for IncludesTypeConstraint's isOnValue as well.
+    // TODO: We should also test for IncludesTypeConstraint's onValue as well.
     const base = new mdl.DataElement(new mdl.Identifier('shr.test', 'ChoiceValue'))
       .withValue(new mdl.ChoiceValue()
         .withMinMax(1,1)


### PR DESCRIPTION
CIMCORE is generated through a strict definition of JSON output in each of the model files. It was done this way (as opposed to creating a separate CIMCORE output tool) in order to limit an unnecessary increase in tools and dependencies.

Between the various components of `DataElement`, `ValueSets`, and `Mapping`, the `toJSON` methods are meant to be compositional, building off each other and their parents.

The majority of the 'logic' can be found in the `toJSON` function of `Value`. That is where the more complex hierarchical constraint structure is found.

Here is a clean output run on the latest version of the spec.
[canonicaljson.zip](https://github.com/standardhealth/shr-models/files/1606667/canonicaljson.zip)
