### PR TITLE
Add support for special words (e.g., _Value, _Entry, _Concept)

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -144,7 +144,9 @@ class DataElementSpecifications {
   }
 
   findByIdentifier(identifier) {
-    return this.find(identifier.namespace, identifier.name);
+    if (identifier) {
+      return this.find(identifier.namespace, identifier.name);
+    }
   }
 }
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -48,7 +48,7 @@ function clearEmptyFields(object, iteratively = false) {
 }
 
 class Specifications {
- 
+
   constructor() {
     this._namespaces = new NamespaceSpecifications();
     this._dataElements = new DataElementSpecifications();
@@ -65,7 +65,7 @@ class Specifications {
 }
 
 class NamespaceSpecifications {
- 
+
   constructor() {
     this._nsMap = new Map();
   }
@@ -82,7 +82,7 @@ class NamespaceSpecifications {
 }
 
 class DataElementSpecifications {
- 
+
   constructor() {
     this._nsMap = new Map();
     this._grammarVersions = new Map();
@@ -129,6 +129,15 @@ class DataElementSpecifications {
   }
 
   find(namespace, name) {
+    // Special case logic for the _Entry and _Concept keywords
+    if (namespace === '') {
+      const id = new Identifier(namespace, name);
+      if (id.isEntryKeyWord) {
+        [namespace, name] = ['shr.base', 'Entry'];
+      } else if (id.isConceptKeyWord) {
+        [namespace, name] = ['shr.core', 'CodeableConcept'];
+      }
+    }
     if (this._nsMap.has(namespace)) {
       return this._nsMap.get(namespace).get(name);
     }
@@ -140,7 +149,7 @@ class DataElementSpecifications {
 }
 
 class ValueSetSpecifications {
- 
+
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -190,7 +199,7 @@ class ValueSetSpecifications {
 }
 
 class CodeSystemSpecifications {
- 
+
   constructor() {
     this._nsMap = new Map();
     this._urlMap = new Map();
@@ -240,7 +249,7 @@ class CodeSystemSpecifications {
 }
 
 class MapSpecifications {
- 
+
   constructor() {
     this._targetMap = new Map();
     this._grammarVersions = new Map();
@@ -346,7 +355,7 @@ class TargetMapSpecifications {
 }
 
 class Namespace {
- 
+
   constructor(namespace, description) {
     this._namespace = namespace; // string
     this._description = description; // string
@@ -375,7 +384,7 @@ class Namespace {
       "description": this.description,
       "external_dependencies" : undefined
     }
-  }  
+  }
 }
 
 class DataElement {
@@ -414,7 +423,7 @@ class DataElement {
     this.addBasedOn(basedOn);
     return this;
   }
-  
+
   // concepts are an array of Concept
   get concepts() { return this._concepts; }
   set concepts(concepts) {
@@ -428,7 +437,7 @@ class DataElement {
     this.addConcept(concept);
     return this;
   }
-  
+
   // a description is a string
   get description() { return this._description; }
   set description(description) {
@@ -439,7 +448,7 @@ class DataElement {
     this.description = description;
     return this;
   }
-  
+
   // Data elements should have a value, or a set of fields, or both a value and set of fields.
   get value() { return this._value; }
   set value(value) {
@@ -450,7 +459,7 @@ class DataElement {
     this.value = value;
     return this;
   }
-  
+
   // Data elements should have a value, or a set of fields, or both a value and set of fields.
   // Fields cannot be primitive values.
   get fields() { return this._fields; }
@@ -465,7 +474,7 @@ class DataElement {
     this.addField(field);
     return this;
   }
-  
+
   // the Version of the grammar used to define this element
   get grammarVersion() { return this._grammarVersion; }
   set grammarVersion(grammarVersion) {
@@ -520,9 +529,9 @@ class DataElement {
       "value":        this.value != null ? this.value.toJSON() : undefined,
       "fields":       this._fields.map(f => f.toJSON()),
     };
-    
+
     clearEmptyFields(output, true)
-    
+
     return output;
   }
 }
@@ -574,7 +583,7 @@ class Concept {
 }
 
 class Identifier {
- 
+
   constructor(namespace, name) {
     this._namespace = namespace; // string
     this._name = name; // string
@@ -582,14 +591,29 @@ class Identifier {
 
   get namespace() { return this._namespace; }
   get name() { return this._name; }
-  get fqn() { return this.isPrimitive || this.isValueKeyWord ? this._name : `${this._namespace}.${this._name}`; }
+  get fqn() { return (this.isPrimitive || this.isSpecialKeyWord) ? this._name : `${this._namespace}.${this._name}`; }
 
   get isPrimitive() {
     return this._namespace === PRIMITIVE_NS;
   }
 
+  get isConceptKeyWord() {
+    return this._namespace === '' && this._name === '_Concept';
+  }
+
+  get isEntryKeyWord() {
+    // TODO: Remove backwards compatibility w/ 'Entry' in next major rev
+    return this._namespace === '' && (this._name === '_Entry' || this._name === 'Entry');
+  }
+
   get isValueKeyWord() {
-    return this._namespace === '' && this._name === 'Value';
+    // TODO: Remove backwards compatibility w/ 'Value' in next major rev
+    return this._namespace === '' && (this._name === '_Value' || this._name === 'Value');
+  }
+
+  get isSpecialKeyWord() {
+    // TODO: Remove backwards compatibility w/ 'Entry' and 'Value' in next major rev
+    return this._namespace === '' && (this._name.startsWith('_') || this._name === 'Entry' || this._name === 'Value');
   }
 
   equals(other) {
@@ -609,14 +633,14 @@ class Identifier {
 }
 
 class PrimitiveIdentifier extends Identifier {
- 
+
   constructor(name) {
     super(PRIMITIVE_NS, name);
   }
 }
 
 class Cardinality {
- 
+
   constructor(min, max) {
     this._min = min; // number
     this._max = max; // number|undefined
@@ -663,7 +687,7 @@ class Cardinality {
   }
   get history() { return this._history; }
   set history(history) { this._history = history; }
-  // withHistory is a convenience function for chaining  
+  // withHistory is a convenience function for chaining
   withHistory(card) {
     this.addHistory(card);
     return this;
@@ -721,7 +745,7 @@ class Cardinality {
 }
 
 class Constraint {
- 
+
   constructor(path = []) {
     this._path = path;
   }
@@ -780,7 +804,7 @@ class Constraint {
 
 // ValueSetConstraint only makes sense on a code or Coding type value
 class ValueSetConstraint extends Constraint {
- 
+
   constructor(valueSet, path, bindingStrength=REQUIRED) {
     super(path);
     this._valueSet = valueSet;
@@ -825,7 +849,7 @@ class ValueSetConstraint extends Constraint {
 
 // CodeConstraint only makes sense on a code or Coding type value
 class CodeConstraint extends Constraint {
- 
+
   constructor(code, path) {
     super(path);
     this._code = code;
@@ -877,7 +901,7 @@ class IncludesCodeConstraint extends Constraint {
         this._code.equals(other.code) &&
         this._pathsAreEqual(other);
   }
-  
+
   toJSON() {
     return Object.assign({
       "system": this._code.system,
@@ -888,7 +912,7 @@ class IncludesCodeConstraint extends Constraint {
 
 // BooleanConstraint only makes sense on a boolean
 class BooleanConstraint extends Constraint {
- 
+
   constructor(value, path) {
     super(path);
     this._value = value;
@@ -911,7 +935,7 @@ class BooleanConstraint extends Constraint {
   toJSON() {
     var constraint = super.toJSON();
     delete constraint["path"];
-    
+
     return Object.assign({
       "type": "boolean",
       "value": this.value,
@@ -920,7 +944,7 @@ class BooleanConstraint extends Constraint {
 }
 
 class TypeConstraint extends Constraint {
- 
+
   constructor(isA, path, onValue = false) {
     super(path);
     this._isA = isA;
@@ -953,7 +977,7 @@ class TypeConstraint extends Constraint {
         this._pathsAreEqual(other);
   }
 
-  toJSON() {    
+  toJSON() {
     return Object.assign({
       "fqn": this.isA.fqn,
       "onValue": this.onValue
@@ -962,7 +986,7 @@ class TypeConstraint extends Constraint {
 }
 
 class IncludesTypeConstraint extends Constraint {
- 
+
   constructor(isA, card, path, onValue=false) {
     super(path);
     this._isA = isA;
@@ -994,14 +1018,14 @@ class IncludesTypeConstraint extends Constraint {
   toJSON() {
     return Object.assign({
       "fqn": this.isA.fqn,
-      "card": this.card.toJSON(), 
+      "card": this.card.toJSON(),
       "onValue": this.onValue
     }, super.toJSON())
   }
 }
 
 class CardConstraint extends Constraint {
- 
+
   constructor(card, path) {
     super(path);
     this._card = card;
@@ -1027,7 +1051,7 @@ class CardConstraint extends Constraint {
 }
 
 class ConstraintsFilter {
- 
+
   constructor(constraints = []) {
     this._constraints = constraints;
   }
@@ -1097,7 +1121,7 @@ class ConstraintsFilter {
 }
 
 class Value {
- 
+
   constructor() {
     this._constraints = [];
   }
@@ -1252,7 +1276,7 @@ class Value {
 
     return true;
   }
- 
+
   toJSON() {
     const constraints = this._constraints.reduce((out, constraint, i) => {
       let key = constraint.constructor.name.replace(/constraint/i, '').replace(/^[a-zA-Z]/, (s) => s.toLowerCase());
@@ -1261,7 +1285,7 @@ class Value {
       const arrConstraints  = ['includesType', 'includesCode'];
       const dicConstraints  = ['type', 'valueSet', 'card'];
       const valConstraints  = ['boolean', 'code'];
-      
+
       const addToPath = (outputDict, skipCard=false) => {
         if (skipCard && key == 'card') return;
 
@@ -1273,7 +1297,7 @@ class Value {
           outputDict[key] = constraintJSON
         } else if (valConstraints.includes(key)) {
           outputDict['fixedValue'] = constraintJSON
-        }    
+        }
       }
 
       if (constraint.path.length == 0) addToPath(out, true);
@@ -1285,7 +1309,7 @@ class Value {
           currentSubField = currentSubField['subpaths'][subP.fqn];
         })
         addToPath(currentSubField)
-      }   
+      }
 
       return out;
     }, {}
@@ -1295,7 +1319,7 @@ class Value {
     if (this.card != null && this.effectiveCard != null && this.card != this.effectiveCard && this.card.history) {
       card.history = this.card.history
     }
-    
+
     return {
       "valueType": this.constructor.name,
       "card": (card) ? card.toJSON() : "TBD",
@@ -1309,7 +1333,7 @@ class Value {
 }
 
 class IdentifiableValue extends Value {
- 
+
   constructor(identifier) {
     super();
     this._identifier = identifier; // Identifier
@@ -1359,19 +1383,19 @@ class IdentifiableValue extends Value {
   toString() {
     return this.identifier.name;
   }
- 
+
   toJSON() {
     return Object.assign(
       {
         "fqn": this.identifier.fqn,
       },
       super.toJSON()
-    );  
-  }  
+    );
+  }
 }
 
 class RefValue extends IdentifiableValue {
- 
+
   constructor(identifier) {
     super(identifier);
   }
@@ -1389,7 +1413,7 @@ class RefValue extends IdentifiableValue {
 
 class ChoiceValue extends Value {
 
- 
+
   constructor() {
     super();
     this._options = []; // Value[]
@@ -1461,7 +1485,7 @@ class ChoiceValue extends Value {
     str += ')';
     return str;
   }
- 
+
   toJSON() {
     return Object.assign(super.toJSON(), {
       "options": this._options.map(v => {
@@ -1478,7 +1502,7 @@ class ChoiceValue extends Value {
 // constraint is applied without knowing the full context of the current data element (in the case of the importer).
 // If a data element is fully resolved, it should never contain an IncompleteValue.
 class IncompleteValue extends IdentifiableValue {
- 
+
   constructor(identifier) {
     super(identifier);
   }
@@ -1495,7 +1519,7 @@ class IncompleteValue extends IdentifiableValue {
 }
 
 class TBD extends Value{
- 
+
   constructor(text) {
     super();
     this._text = text;
@@ -1528,7 +1552,7 @@ class TBD extends Value{
   toString() {
     return this._text ? `TBD(${this._text})` : 'TBD';
   }
- 
+
   toJSON() {
     return Object.assign(
       {
@@ -1540,7 +1564,7 @@ class TBD extends Value{
 }
 
 class ValueSet  {
- 
+
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1672,7 +1696,7 @@ class ValueSet  {
     var out = {
       "name":        this._identifier._name,
       "namespace":   this._identifier.namespace,
-      "fqn":         this._identifier.fqn,      
+      "fqn":         this._identifier.fqn,
       "description": this._description,
       "concepts":    this.concepts.map(c => c.toJSON()),
       "url":         this._url,
@@ -1685,7 +1709,7 @@ class ValueSet  {
       }
     }
 
-    clearEmptyFields(out, true);    
+    clearEmptyFields(out, true);
 
     return out;
   }
@@ -1693,7 +1717,7 @@ class ValueSet  {
 
 // Note -- this should be consider abstract.  Do not instantiate!
 class ValueSetCodeRule {
- 
+
   constructor(code) {
     this._code = code;
   }
@@ -1703,7 +1727,7 @@ class ValueSetCodeRule {
 
 // ValueSetIncludesCodeRule indicates that the given code should be directly included in the value set
 class ValueSetIncludesCodeRule extends ValueSetCodeRule {
- 
+
   constructor(code) {
     super(code);
   }
@@ -1723,7 +1747,7 @@ class ValueSetIncludesCodeRule extends ValueSetCodeRule {
 
 // ValueSetIncludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be included in the value set
 class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
- 
+
   constructor(code) {
     super(code);
   }
@@ -1743,7 +1767,7 @@ class ValueSetIncludesDescendentsRule extends ValueSetCodeRule {
 
 // ValueSetExcludesDescendentsRule indicates that the given code and it's descendents (in SNOMED-CT) should be excluded from the value set
 class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
- 
+
   constructor(code) {
     super(code);
   }
@@ -1763,7 +1787,7 @@ class ValueSetExcludesDescendentsRule extends ValueSetCodeRule {
 
 // ValueSetIncludesFromCodeSystemRule indicates that all codes in the given code system should be included in the value set
 class ValueSetIncludesFromCodeSystemRule {
- 
+
   constructor(system) {
     this._system = system;
   }
@@ -1781,7 +1805,7 @@ class ValueSetIncludesFromCodeSystemRule {
 
 // ValueSetIncludesFromCodeRule indicates that codes referenced by the given code should be included in the value set
 class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
- 
+
   constructor(code) {
     super(code);
   }
@@ -1800,7 +1824,7 @@ class ValueSetIncludesFromCodeRule extends ValueSetCodeRule {
 }
 
 class ValueSetRulesFilter {
- 
+
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -1830,7 +1854,7 @@ class ValueSetRulesFilter {
 }
 
 class CodeSystem  {
- 
+
   constructor(identifier, url) {
     this._identifier = identifier;
     this._url = url;
@@ -1893,7 +1917,7 @@ class CodeSystem  {
 
 
 class ElementMapping {
- 
+
   constructor(identifier, targetSpec, targetItem) {
     this._identifier = identifier;
     this._targetSpec = targetSpec;
@@ -1979,7 +2003,7 @@ class ElementMapping {
 
   toJSON() {
     /* TODO: make field mappings hierarchial
-    let fieldMappings = this.rulesFilter.field._rules.reduce((dict, m) => {      
+    let fieldMappings = this.rulesFilter.field._rules.reduce((dict, m) => {
       var paths = m.sourcePath.map(p => p.fqn).slice();
       var currDict = dict;
       while (paths.length > 0) {
@@ -1994,7 +2018,7 @@ class ElementMapping {
       return dict;
     }, {})
     */
-    
+
     let out = {
       "name": this.identifier.name,
       "namespace": this.identifier.namespace,
@@ -2009,13 +2033,13 @@ class ElementMapping {
     }
 
     clearEmptyFields(out, true)
-    
+
     return out;
   }
 }
 
 class FieldMappingRule {
- 
+
   constructor(sourcePath = [], target = '') {
     this._sourcePath = sourcePath; // array of identifiers
     this._target = target; // string
@@ -2045,7 +2069,7 @@ class FieldMappingRule {
 }
 
 class CardinalityMappingRule {
- 
+
   constructor(target = '', cardinality) {
     this._target = target;   // string
     this._cardinality = cardinality; // Cardinality
@@ -2071,7 +2095,7 @@ class CardinalityMappingRule {
 }
 
 class FixedValueMappingRule {
- 
+
   constructor(target = '', value='') {
     this._target = target;   // string
     this._value = value; // string
@@ -2097,7 +2121,7 @@ class FixedValueMappingRule {
 }
 
 class MappingRulesFilter {
- 
+
   constructor(rules = []) {
     this._rules = rules;
   }
@@ -2142,7 +2166,7 @@ class MappingRulesFilter {
 }
 
 class Version {
- 
+
   constructor(major, minor = 0, patch = 0) {
     this._major = major;
     this._minor = minor;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Update the `Identifier` class to have getters for checking if an Identifier is one of the special keywords, and also update the data element lookup to recognize `_Entry` and `_Concept` and return the appropriate data elements (`shr.base.Entry` and `shr.core.CodeableConcept`).  This allows much of the tooling not to need special handling for these words.

Bonus -- my editor trims all trailing whitespace.  This is a good practice, so I left it in -- but sorry for all of the whitespace changes.