### PR TITLE
Fix possibleIdentifiers (affects shr-expand only)

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -1589,7 +1589,7 @@ class Value {
 
     let card = this.effectiveCard;
     if (this.card != null && this.effectiveCard != null && this.card != this.effectiveCard && this.card.history) {
-      card.history = this.card.history
+      card.history = this.card.history;
     }
 
     return {
@@ -1624,11 +1624,17 @@ class IdentifiableValue extends Value {
 
   getPossibleIdentifiers(withIncludesTypeIdentifiers=false) {
     const idMap = new Map();
+    // First add its original identifier
     idMap.set(this.identifier.fqn, this.identifier);
+    // Then add its effective identifier
+    // NOTE: This is usually in the constraint history, but at one point in shr-expand, it might not be
+    idMap.set(this.effectiveIdentifier.fqn, this.effectiveIdentifier);
+    // Then add any other historical type constraints
     const typeConstraintsHistories = this.constraintHistory.type.own.histories;
     for (const tch of typeConstraintsHistories) {
       idMap.set(tch.constraint.isA.fqn, tch.constraint.isA);
     }
+    // Then add any include type constraints if requested
     if (withIncludesTypeIdentifiers) {
       const includesTypeConstraints = this.constraintsFilter.own.includesType.constraints;
       for (const itc of includesTypeConstraints) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-models",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "Models used to represent SHR namespaces, data elements, value sets, code systems, and mappings for import/export",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
In shr-expand, there is a point where constraint histories are not yet generated, but getPossibleIdentifiers is used.  In this case, we need to still get back the effectiveIdentifier even though the constraint history isn't there yet.

This was causing a number of incorrect errors and a crash in standardhealth/shr_spec#master when the CLI was run using shr-models 5.5.1.  With this fix, the incorrect errors go away and the crash no longer occurs.