### PR TITLE
Sprint 41 Changes

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -830,6 +830,12 @@ class Identifier {
     return this._namespace === '' && (this._name.startsWith('_') || this._name === 'Entry' || this._name === 'Value');
   }
 
+  get isQuantity() {
+    // NOTE: Parts of the framework need special handling for quantity, so we need a consistent way to identify it.
+    // In addtion, we also want to support it in the old namespace (shr.core) for backwards-compatibility.
+    return this._name === 'Quantity' && (this._namespace === 'obf.datatype' || this._namespace === 'shr.core');
+  }
+
   equals(other) {
     if (typeof other === 'undefined' || other == null || !(other instanceof Identifier)) {
       return false;


### PR DESCRIPTION
Now that Quantity can be from shr.core or obf.datatype, we want a simple, centralized function to detect if an identifier is a Quantity.  This is needed due to some special handling around Quantity.

PR 1 of 4.