### PR TITLE
Remove support for Entry/_Entry keywords

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -145,12 +145,10 @@ class DataElementSpecifications {
   }
 
   find(namespace, name) {
-    // Special case logic for the _Entry and _Concept keywords
+    // Special case logic for the _Concept keyword
     if (namespace === '') {
       const id = new Identifier(namespace, name);
-      if (id.isEntryKeyWord) {
-        [namespace, name] = ['shr.base', 'Entry'];
-      } else if (id.isConceptKeyWord) {
+      if (id.isConceptKeyWord) {
         [namespace, name] = ['primitive', 'concept'];
       }
     }
@@ -765,19 +763,14 @@ class Identifier {
     return this._namespace === '' && this._name === '_Concept';
   }
 
-  get isEntryKeyWord() {
-    // TODO: Remove backwards compatibility w/ 'Entry' in next major rev
-    return this._namespace === '' && (this._name === '_Entry' || this._name === 'Entry');
-  }
-
   get isValueKeyWord() {
     // TODO: Remove backwards compatibility w/ 'Value' in next major rev
     return this._namespace === '' && (this._name === '_Value' || this._name === 'Value');
   }
 
   get isSpecialKeyWord() {
-    // TODO: Remove backwards compatibility w/ 'Entry' and 'Value' in next major rev
-    return this._namespace === '' && (this._name.startsWith('_') || this._name === 'Entry' || this._name === 'Value');
+    // TODO: Remove backwards compatibility w/ 'Value' in next major rev
+    return this._namespace === '' && (this._name.startsWith('_') || this._name === 'Value');
   }
 
   get isQuantity() {


### PR DESCRIPTION
"Entryness" affects implementations of data elements, but should not automatically add special fields to the model itself.  As such, there is no longer any valid need for Entry/_Entry keywords.

This is PR 1 of 7 in the overall effort to remove the need for the `shr.base.Entry` element.

1. shr-models
2. shr-text-import (standardhealth/shr-text-import#110)
3. shr-expand (standardhealth/shr-expand#49)
4. shr-json-javadoc (standardhealth/shr-json-javadoc#28)
5. shr-json-schema-export (standardhealth/shr-json-schema-export#17)
6. shr-fhir-export (standardhealth/shr-fhir-export#165)
7. shr-es6-export (standardhealth/shr-es6-export#60)